### PR TITLE
Add base Electron visualizer architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# AudioVisualizer
+# Audio Visualizer Pro
+
+Base architecture for a cross-platform audio reactive visualizer built with Electron, Three.js and Web APIs.
+
+## Development
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start the application
+   ```bash
+   npm start
+   ```
+
+The current skeleton includes:
+- Electron windows for visual engine and control panel
+- Audio and MIDI engine basics
+- Visualizer core with modular presets
+- Example preset: GeometricParticles

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "audio-visualizer-pro",
+  "version": "0.1.0",
+  "description": "Standalone audio reactive visualizer for VJs",
+  "main": "src/main.js",
+  "type": "module",
+  "scripts": {
+    "start": "electron ."
+  },
+  "dependencies": {
+    "electron": "^25.5.0",
+    "three": "^0.158.0",
+    "cannon-es": "^0.20.0",
+    "tweakpane": "^3.1.0"
+  }
+}

--- a/src/core/AudioEngine.js
+++ b/src/core/AudioEngine.js
@@ -1,0 +1,30 @@
+export class AudioEngine {
+    constructor() {
+        this.audioCtx = null;
+        this.analyser = null;
+        this.freqData = null;
+    }
+
+    async init() {
+        if (!navigator.mediaDevices) {
+            console.warn('Media devices not available');
+            return;
+        }
+        this.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        const source = this.audioCtx.createMediaStreamSource(stream);
+        this.analyser = this.audioCtx.createAnalyser();
+        this.analyser.fftSize = 2048;
+        source.connect(this.analyser);
+        this.freqData = new Uint8Array(this.analyser.frequencyBinCount);
+    }
+
+    update() {
+        if (!this.analyser) return;
+        this.analyser.getByteFrequencyData(this.freqData);
+    }
+
+    getFrequencies() {
+        return this.freqData;
+    }
+}

--- a/src/core/MidiEngine.js
+++ b/src/core/MidiEngine.js
@@ -1,0 +1,29 @@
+export class MidiEngine {
+    constructor() {
+        this.inputs = [];
+        this.callbacks = new Map();
+    }
+
+    async init() {
+        if (!navigator.requestMIDIAccess) {
+            console.warn('Web MIDI API not supported');
+            return;
+        }
+        const access = await navigator.requestMIDIAccess();
+        access.inputs.forEach(input => {
+            input.onmidimessage = this._onMIDIMessage.bind(this);
+            this.inputs.push(input);
+        });
+    }
+
+    on(type, fn) {
+        this.callbacks.set(type, fn);
+    }
+
+    _onMIDIMessage(message) {
+        const [status, data1, data2] = message.data;
+        const type = status & 0xf0;
+        const cb = this.callbacks.get(type);
+        if (cb) cb({ status, data1, data2 });
+    }
+}

--- a/src/core/SettingsManager.js
+++ b/src/core/SettingsManager.js
@@ -1,0 +1,10 @@
+export class SettingsManager {
+    get(key, defaultValue) {
+        const value = localStorage.getItem(key);
+        return value ? JSON.parse(value) : defaultValue;
+    }
+
+    set(key, value) {
+        localStorage.setItem(key, JSON.stringify(value));
+    }
+}

--- a/src/core/VisualizerCore.js
+++ b/src/core/VisualizerCore.js
@@ -1,0 +1,71 @@
+import * as THREE from 'three';
+
+export class Visualizer {
+    constructor(canvas, { audio, midi, settings }) {
+        this.canvas = canvas;
+        this.audio = audio;
+        this.midi = midi;
+        this.settings = settings;
+
+        this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+        this.renderer.setSize(window.innerWidth, window.innerHeight);
+        this.scene = new THREE.Scene();
+        this.camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+        this.camera.position.z = 5;
+
+        this.presets = new Map();
+        this.currentPreset = null;
+
+        window.addEventListener('resize', () => this._onResize());
+    }
+
+    registerPreset(name, presetClass) {
+        this.presets.set(name, presetClass);
+    }
+
+    loadPreset(name) {
+        if (this.currentPreset && this.currentPreset.dispose) {
+            this.currentPreset.dispose();
+        }
+        this.scene.clear();
+        const PresetClass = this.presets.get(name);
+        if (!PresetClass) {
+            console.warn(`Preset ${name} not found`);
+            return;
+        }
+        this.currentPreset = new PresetClass(this.scene, this.audio, this.midi, this.settings);
+    }
+
+    update() {
+        this.audio.update();
+        if (this.currentPreset && this.currentPreset.update) {
+            this.currentPreset.update();
+        }
+        this.renderer.render(this.scene, this.camera);
+    }
+
+    setParam(name, value) {
+        if (this.currentPreset && this.currentPreset.onParamChange) {
+            this.currentPreset.onParamChange(name, value);
+        }
+    }
+
+    _onResize() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        this.renderer.setSize(w, h);
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+    }
+}
+
+export class VisualPreset {
+    constructor(scene, audio, midi, settings) {
+        this.scene = scene;
+        this.audio = audio;
+        this.midi = midi;
+        this.settings = settings;
+    }
+    update() {}
+    dispose() {}
+}

--- a/src/effects/PostProcessingManager.js
+++ b/src/effects/PostProcessingManager.js
@@ -1,0 +1,12 @@
+export class PostProcessingManager {
+    constructor(renderer, scene, camera) {
+        this.renderer = renderer;
+        this.scene = scene;
+        this.camera = camera;
+        // Placeholder for post-processing chain
+    }
+
+    update() {
+        // Apply post-processing
+    }
+}

--- a/src/libs/cannon-es.js
+++ b/src/libs/cannon-es.js
@@ -1,0 +1,1 @@
+export * from 'cannon-es';

--- a/src/libs/three.min.js
+++ b/src/libs/three.min.js
@@ -1,0 +1,1 @@
+export * from 'three';

--- a/src/libs/tweakpane.min.js
+++ b/src/libs/tweakpane.min.js
@@ -1,0 +1,1 @@
+export * from 'tweakpane';

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,51 @@
+import { app, BrowserWindow, ipcMain } from 'electron';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+let visualWindow;
+let controlWindow;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function createVisualWindow() {
+    visualWindow = new BrowserWindow({
+        width: 1920,
+        height: 1080,
+        frame: false,
+        webPreferences: {
+            preload: path.join(__dirname, 'preload.js'),
+            contextIsolation: true,
+            nodeIntegration: false
+        }
+    });
+    visualWindow.loadFile(path.join(__dirname, 'renderer', 'main.html'));
+}
+
+function createControlWindow() {
+    controlWindow = new BrowserWindow({
+        width: 400,
+        height: 600,
+        webPreferences: {
+            preload: path.join(__dirname, 'preload.js'),
+            contextIsolation: true,
+            nodeIntegration: false
+        }
+    });
+    controlWindow.loadFile(path.join(__dirname, 'renderer', 'controls.html'));
+}
+
+app.whenReady().then(() => {
+    createVisualWindow();
+    createControlWindow();
+});
+
+app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') app.quit();
+});
+
+ipcMain.on('control-change', (_event, data) => {
+    if (visualWindow) {
+        visualWindow.webContents.send('control-change', data);
+    }
+});

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,6 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('electronAPI', {
+    send: (channel, data) => ipcRenderer.send(channel, data),
+    on: (channel, callback) => ipcRenderer.on(channel, (_event, data) => callback(data))
+});

--- a/src/renderer/controls.html
+++ b/src/renderer/controls.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Audio Visualizer Pro - Control Panel</title>
+    <style>
+        body { margin:0; padding:0; font-family: sans-serif; background:#1e1e1e; color:#eee; }
+    </style>
+</head>
+<body>
+    <div id="controls"></div>
+    <script type="module" src="./controls.js"></script>
+</body>
+</html>

--- a/src/renderer/controls.js
+++ b/src/renderer/controls.js
@@ -1,0 +1,8 @@
+import { Pane } from 'tweakpane';
+
+const pane = new Pane({ container: document.getElementById('controls') });
+const params = { sensitivity: 0.5 };
+
+pane.addBinding(params, 'sensitivity', { min: 0, max: 1 }).on('change', (ev) => {
+    window.electronAPI.send('control-change', { param: 'sensitivity', value: ev.value });
+});

--- a/src/renderer/main.html
+++ b/src/renderer/main.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Audio Visualizer Pro - Visual Engine</title>
+    <style>
+        html, body { margin:0; padding:0; overflow:hidden; background:#000; }
+        canvas { display:block; }
+    </style>
+</head>
+<body>
+    <canvas id="visualizer-canvas"></canvas>
+    <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,0 +1,39 @@
+import { AudioEngine } from '../core/AudioEngine.js';
+import { MidiEngine } from '../core/MidiEngine.js';
+import { Visualizer } from '../core/VisualizerCore.js';
+import { SettingsManager } from '../core/SettingsManager.js';
+import { GeometricParticles } from '../visuals/GeometricParticles.js';
+import { FluidParticles } from '../visuals/FluidParticles.js';
+import { EvolutiveParticles } from '../visuals/EvolutiveParticles.js';
+import { AbstractLines } from '../visuals/AbstractLines.js';
+import { MoebiusBand } from '../visuals/MoebiusBand.js';
+import { AbstractShapes } from '../visuals/AbstractShapes.js';
+
+const canvas = document.getElementById('visualizer-canvas');
+
+const audio = new AudioEngine();
+const midi = new MidiEngine();
+const settings = new SettingsManager();
+
+const visualizer = new Visualizer(canvas, { audio, midi, settings });
+visualizer.registerPreset('GeometricParticles', GeometricParticles);
+visualizer.registerPreset('FluidParticles', FluidParticles);
+visualizer.registerPreset('EvolutiveParticles', EvolutiveParticles);
+visualizer.registerPreset('AbstractLines', AbstractLines);
+visualizer.registerPreset('MoebiusBand', MoebiusBand);
+visualizer.registerPreset('AbstractShapes', AbstractShapes);
+
+window.electronAPI.on('control-change', ({ param, value }) => {
+    visualizer.setParam(param, value);
+});
+
+(async () => {
+    await audio.init();
+    await midi.init();
+    visualizer.loadPreset('GeometricParticles');
+    function animate() {
+        requestAnimationFrame(animate);
+        visualizer.update();
+    }
+    animate();
+})();

--- a/src/visuals/AbstractLines.js
+++ b/src/visuals/AbstractLines.js
@@ -1,0 +1,12 @@
+import { VisualPreset } from '../core/VisualizerCore.js';
+
+export class AbstractLines extends VisualPreset {
+    constructor(scene, audio, midi, settings) {
+        super(scene, audio, midi, settings);
+        // Placeholder for abstract lines
+    }
+
+    update() {
+        // Update lines
+    }
+}

--- a/src/visuals/AbstractShapes.js
+++ b/src/visuals/AbstractShapes.js
@@ -1,0 +1,12 @@
+import { VisualPreset } from '../core/VisualizerCore.js';
+
+export class AbstractShapes extends VisualPreset {
+    constructor(scene, audio, midi, settings) {
+        super(scene, audio, midi, settings);
+        // Placeholder for abstract shapes
+    }
+
+    update() {
+        // Update shapes
+    }
+}

--- a/src/visuals/EvolutiveParticles.js
+++ b/src/visuals/EvolutiveParticles.js
@@ -1,0 +1,12 @@
+import { VisualPreset } from '../core/VisualizerCore.js';
+
+export class EvolutiveParticles extends VisualPreset {
+    constructor(scene, audio, midi, settings) {
+        super(scene, audio, midi, settings);
+        // Placeholder for evolutive particles
+    }
+
+    update() {
+        // Update lifecycle of particles
+    }
+}

--- a/src/visuals/FluidParticles.js
+++ b/src/visuals/FluidParticles.js
@@ -1,0 +1,12 @@
+import { VisualPreset } from '../core/VisualizerCore.js';
+
+export class FluidParticles extends VisualPreset {
+    constructor(scene, audio, midi, settings) {
+        super(scene, audio, midi, settings);
+        // Placeholder for fluid particle system
+    }
+
+    update() {
+        // Update fluid particles
+    }
+}

--- a/src/visuals/GeometricParticles.js
+++ b/src/visuals/GeometricParticles.js
@@ -1,0 +1,37 @@
+import * as THREE from 'three';
+import { VisualPreset } from '../core/VisualizerCore.js';
+
+export class GeometricParticles extends VisualPreset {
+    constructor(scene, audio, midi, settings) {
+        super(scene, audio, midi, settings);
+        this.params = { sensitivity: 0.5 };
+        const count = 1000;
+        const geometry = new THREE.BufferGeometry();
+        const positions = new Float32Array(count * 3);
+        for (let i = 0; i < count; i++) {
+            positions[i * 3] = (Math.random() - 0.5) * 10;
+            positions[i * 3 + 1] = (Math.random() - 0.5) * 10;
+            positions[i * 3 + 2] = (Math.random() - 0.5) * 10;
+        }
+        geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        const material = new THREE.PointsMaterial({ color: 0xffffff, size: 0.05 });
+        this.points = new THREE.Points(geometry, material);
+        this.scene.add(this.points);
+    }
+
+    update() {
+        const freq = this.audio.getFrequencies();
+        if (!freq) return;
+        const positions = this.points.geometry.attributes.position.array;
+        for (let i = 0; i < freq.length && i < positions.length / 3; i++) {
+            positions[i * 3 + 1] = (freq[i] / 255) * 5 * this.params.sensitivity - 2.5;
+        }
+        this.points.geometry.attributes.position.needsUpdate = true;
+    }
+
+    onParamChange(name, value) {
+        if (name === "sensitivity") {
+            this.params.sensitivity = value;
+        }
+    }
+}

--- a/src/visuals/MoebiusBand.js
+++ b/src/visuals/MoebiusBand.js
@@ -1,0 +1,12 @@
+import { VisualPreset } from '../core/VisualizerCore.js';
+
+export class MoebiusBand extends VisualPreset {
+    constructor(scene, audio, midi, settings) {
+        super(scene, audio, midi, settings);
+        // Placeholder for Möbius band visualization
+    }
+
+    update() {
+        // Update Möbius band
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Electron main and control windows with IPC bridge
- introduce AudioEngine, MidiEngine, and Visualizer core with preset system
- add example GeometricParticles preset and stubs for additional visuals

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68978af728548333b140a7bf028d2f69