### PR TITLE
Add dynamic visual preset controls

### DIFF
--- a/visuals/abstract_lines.py
+++ b/visuals/abstract_lines.py
@@ -1,4 +1,3 @@
-from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 from PyQt6.QtGui import QOpenGLContext, QSurfaceFormat
 from OpenGL.GL import *
 from OpenGL.GLU import *
@@ -6,7 +5,9 @@ import numpy as np
 import ctypes
 import os
 
-class AbstractLinesVisualizer(QOpenGLWidget):
+from .base_visualizer import BaseVisualizer
+
+class AbstractLinesVisualizer(BaseVisualizer):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setFormat(QSurfaceFormat())
@@ -16,6 +17,21 @@ class AbstractLinesVisualizer(QOpenGLWidget):
         self.num_lines = 1000
         self.line_data = None
         self.time = 0.0
+        self.line_width = 1.0
+
+    def get_controls(self):
+        return {
+            "Line Width": {
+                "type": "slider",
+                "min": 1,
+                "max": 10,
+                "value": int(self.line_width),
+            }
+        }
+
+    def update_control(self, name, value):
+        if name == "Line Width":
+            self.line_width = float(value)
 
     def initializeGL(self):
         glClearColor(0.0, 0.0, 0.0, 1.0)
@@ -97,6 +113,7 @@ class AbstractLinesVisualizer(QOpenGLWidget):
         model = self.translate(0.0, 0.0, 0.0) # No animation for now
         glUniformMatrix4fv(glGetUniformLocation(self.shader_program, "model"), 1, GL_FALSE, model)
 
+        glLineWidth(self.line_width)
         glBindVertexArray(self.VAO)
         glDrawArrays(GL_LINES, 0, self.num_lines * 2)
         glBindVertexArray(0)

--- a/visuals/base_visualizer.py
+++ b/visuals/base_visualizer.py
@@ -1,0 +1,16 @@
+from PyQt6.QtOpenGLWidgets import QOpenGLWidget
+
+class BaseVisualizer(QOpenGLWidget):
+    """Common interface for all visualizers with runtime controls."""
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def get_controls(self):
+        """Return a dict describing available controls.
+        Example: {"Name": {"type": "slider", "min":0, "max":100, "value":50}}
+        """
+        return {}
+
+    def update_control(self, name, value):
+        """Update internal parameter identified by name with new value."""
+        pass

--- a/visuals/evolutive_particles.py
+++ b/visuals/evolutive_particles.py
@@ -1,4 +1,3 @@
-from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 from PyQt6.QtGui import QOpenGLContext, QSurfaceFormat
 from OpenGL.GL import *
 from OpenGL.GLU import *
@@ -6,7 +5,9 @@ import numpy as np
 import ctypes
 import os
 
-class EvolutiveParticlesVisualizer(QOpenGLWidget):
+from .base_visualizer import BaseVisualizer
+
+class EvolutiveParticlesVisualizer(BaseVisualizer):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setFormat(QSurfaceFormat())
@@ -17,6 +18,21 @@ class EvolutiveParticlesVisualizer(QOpenGLWidget):
         self.particle_positions = None
         self.particle_colors = None
         self.time = 0.0
+        self.speed = 0.01
+
+    def get_controls(self):
+        return {
+            "Speed": {
+                "type": "slider",
+                "min": 1,
+                "max": 100,
+                "value": int(self.speed * 100),
+            }
+        }
+
+    def update_control(self, name, value):
+        if name == "Speed":
+            self.speed = float(value) / 100.0
 
     def initializeGL(self):
         glClearColor(0.0, 0.0, 0.0, 1.0)
@@ -94,7 +110,7 @@ class EvolutiveParticlesVisualizer(QOpenGLWidget):
         glUniformMatrix4fv(glGetUniformLocation(self.shader_program, "view"), 1, GL_FALSE, view)
 
         # Simple animation: particles move up and down
-        self.time += 0.01
+        self.time += self.speed
         model = self.translate(0.0, np.sin(self.time) * 0.5, 0.0)
         glUniformMatrix4fv(glGetUniformLocation(self.shader_program, "model"), 1, GL_FALSE, model)
 

--- a/visuals/fluid_particles.py
+++ b/visuals/fluid_particles.py
@@ -1,4 +1,3 @@
-from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 from PyQt6.QtGui import QOpenGLContext, QSurfaceFormat
 from OpenGL.GL import *
 from OpenGL.GLU import *
@@ -8,8 +7,9 @@ import os
 import time
 
 from physics.physics_engine import PhysicsEngine
+from .base_visualizer import BaseVisualizer
 
-class FluidParticlesVisualizer(QOpenGLWidget):
+class FluidParticlesVisualizer(BaseVisualizer):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setFormat(QSurfaceFormat())
@@ -21,6 +21,21 @@ class FluidParticlesVisualizer(QOpenGLWidget):
         self.particle_colors = None
         self.physics_engine = PhysicsEngine()
         self.last_time = time.time()
+        self.point_size = 20.0
+
+    def get_controls(self):
+        return {
+            "Point Size": {
+                "type": "slider",
+                "min": 1,
+                "max": 30,
+                "value": int(self.point_size),
+            }
+        }
+
+    def update_control(self, name, value):
+        if name == "Point Size":
+            self.point_size = float(value)
 
     def initializeGL(self):
         glClearColor(0.0, 0.0, 0.0, 1.0)
@@ -110,7 +125,7 @@ class FluidParticlesVisualizer(QOpenGLWidget):
         model = self.translate(0.0, 0.0, 0.0) # No global model translation for now
         glUniformMatrix4fv(glGetUniformLocation(self.shader_program, "model"), 1, GL_FALSE, model)
 
-        glPointSize(20.0) # Increased point size even further for extreme visibility
+        glPointSize(self.point_size)
 
         # Debug print for particle positions
         if self.particle_positions is not None and len(self.particle_positions) > 0:

--- a/visuals/geometric_particles.py
+++ b/visuals/geometric_particles.py
@@ -1,4 +1,3 @@
-from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 from PyQt6.QtGui import QOpenGLContext, QSurfaceFormat
 from OpenGL.GL import *
 from OpenGL.GLU import *
@@ -6,7 +5,9 @@ import numpy as np
 import ctypes
 import os
 
-class GeometricParticlesVisualizer(QOpenGLWidget):
+from .base_visualizer import BaseVisualizer
+
+class GeometricParticlesVisualizer(BaseVisualizer):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setFormat(QSurfaceFormat())
@@ -17,6 +18,27 @@ class GeometricParticlesVisualizer(QOpenGLWidget):
         self.particle_positions = None
         self.particle_colors = None
         self.time = 0.0
+
+    def get_controls(self):
+        return {
+            "Particle Count": {
+                "type": "slider",
+                "min": 1000,
+                "max": 20000,
+                "value": self.num_particles,
+            }
+        }
+
+    def update_control(self, name, value):
+        if name == "Particle Count":
+            self.num_particles = int(value)
+            if self.VBO:
+                glDeleteBuffers(1, [self.VBO])
+                self.VBO = None
+            if self.VAO:
+                glDeleteVertexArrays(1, [self.VAO])
+                self.VAO = None
+            self.setup_particles()
 
     def initializeGL(self):
         glClearColor(0.0, 0.0, 0.0, 1.0)

--- a/visuals/mobius_band.py
+++ b/visuals/mobius_band.py
@@ -1,4 +1,3 @@
-from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 from PyQt6.QtGui import QOpenGLContext, QSurfaceFormat
 from OpenGL.GL import *
 from OpenGL.GLU import *
@@ -6,7 +5,9 @@ import numpy as np
 import ctypes
 import os
 
-class MobiusBandVisualizer(QOpenGLWidget):
+from .base_visualizer import BaseVisualizer
+
+class MobiusBandVisualizer(BaseVisualizer):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setFormat(QSurfaceFormat())
@@ -17,6 +18,27 @@ class MobiusBandVisualizer(QOpenGLWidget):
         self.num_slices = 20
         self.band_data = None
         self.time = 0.0
+
+    def get_controls(self):
+        return {
+            "Segments": {
+                "type": "slider",
+                "min": 10,
+                "max": 200,
+                "value": self.num_segments,
+            }
+        }
+
+    def update_control(self, name, value):
+        if name == "Segments":
+            self.num_segments = int(value)
+            if self.VBO:
+                glDeleteBuffers(1, [self.VBO])
+                self.VBO = None
+            if self.VAO:
+                glDeleteVertexArrays(1, [self.VAO])
+                self.VAO = None
+            self.setup_band()
 
     def initializeGL(self):
         glClearColor(0.0, 0.0, 0.0, 1.0)


### PR DESCRIPTION
## Summary
- introduce a `BaseVisualizer` with generic control interface
- add per-preset sliders (particle count, point size, etc.)
- generate control widgets dynamically in main control panel

## Testing
- `python -m py_compile main.py visuals/base_visualizer.py visuals/geometric_particles.py visuals/fluid_particles.py visuals/evolutive_particles.py visuals/abstract_lines.py visuals/mobius_band.py visuals/abstract_shapes.py`


------
https://chatgpt.com/codex/tasks/task_e_6897ac9896bc8333997f924dde283614