### PR TITLE
Enable deck previews and fix visual rendering

### DIFF
--- a/ui/control_panel_window.py
+++ b/ui/control_panel_window.py
@@ -168,36 +168,30 @@ class ControlPanelWindow(QMainWindow):
         title.setStyleSheet("color: #00ff00; background-color: #1a1a1a; padding: 10px; border-radius: 5px;")
         deck_layout.addWidget(title)
         
-        # Preview window - DISABLED to avoid OpenGL conflicts
+        # Preview window
         preview_group = QGroupBox("Preview")
         preview_layout = QVBoxLayout(preview_group)
-        
-        # For now, just show a placeholder to avoid OpenGL context issues
-        placeholder_label = QLabel(f"Deck {deck_id} Preview\n(Disabled to prevent conflicts)")
-        placeholder_label.setStyleSheet("color: #888; background-color: #2a2a2a; padding: 40px; text-align: center;")
-        placeholder_label.setFixedSize(250, 200)
-        placeholder_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        preview_layout.addWidget(placeholder_label)
-        
-        # TODO: Re-enable preview when OpenGL context sharing is fixed
-        # try:
-        #     # Get the appropriate deck for preview
-        #     deck = self.mixer_window.deck_a if deck_id == 'A' else self.mixer_window.deck_b
-        #     preview_widget = PreviewGLWidget(deck)
-        #     preview_widget.setFixedSize(250, 200)
-        #     preview_layout.addWidget(preview_widget)
-        #     
-        #     # Store reference to preview widget
-        #     if deck_id == 'A':
-        #         self.preview_a = preview_widget
-        #     else:
-        #         self.preview_b = preview_widget
-        #         
-        # except Exception as e:
-        #     logging.error(f"Error creating preview widget for deck {deck_id}: {e}")
-        #     error_label = QLabel(f"Preview Error: {str(e)}")
-        #     error_label.setStyleSheet("color: red; background-color: #2a2a2a; padding: 10px;")
-        #     preview_layout.addWidget(error_label)
+
+        try:
+            # Get the appropriate deck for preview
+            deck = self.mixer_window.deck_a if deck_id == 'A' else self.mixer_window.deck_b
+            preview_widget = PreviewGLWidget(deck)
+            preview_widget.setFixedSize(250, 200)
+            preview_layout.addWidget(preview_widget)
+
+            # Store reference to preview widget
+            if deck_id == 'A':
+                self.preview_a = preview_widget
+            else:
+                self.preview_b = preview_widget
+
+        except Exception as e:
+            logging.error(f"Error creating preview widget for deck {deck_id}: {e}")
+            error_label = QLabel(f"Preview Error: {str(e)}")
+            error_label.setStyleSheet("color: red; background-color: #2a2a2a; padding: 10px;")
+            error_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            error_label.setFixedSize(250, 200)
+            preview_layout.addWidget(error_label)
         
         deck_layout.addWidget(preview_group)
         
@@ -612,11 +606,10 @@ class ControlPanelWindow(QMainWindow):
     def update_info_and_previews(self):
         """Update preview windows and system information"""
         try:
-            # Preview updates disabled to prevent OpenGL conflicts
-            # if hasattr(self, 'preview_a'):
-            #     self.preview_a.update_preview()
-            # if hasattr(self, 'preview_b'):
-            #     self.preview_b.update_preview()
+            if hasattr(self, 'preview_a'):
+                self.preview_a.update_preview()
+            if hasattr(self, 'preview_b'):
+                self.preview_b.update_preview()
             
             # Update device displays periodically (every 2 seconds)
             if not hasattr(self, '_last_device_update'):

--- a/ui/preview_gl_widget.py
+++ b/ui/preview_gl_widget.py
@@ -87,36 +87,33 @@ class PreviewGLWidget(QOpenGLWidget):
         glBindVertexArray(0)
 
     def paintGL(self):
-        # Temporarily draw a solid color to test if the crash is in rendering
-        glClearColor(0.5, 0.0, 0.5, 1.0) # Magenta color
+        if not self.initialized:
+            glClearColor(0.1, 0.1, 0.2, 1.0)
+            glClear(GL_COLOR_BUFFER_BIT)
+            return
+
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
-        # All other rendering logic will be commented out for this test
 
-        # if not self.initialized:
-        #     return
-            
-        # glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
-        
-        # if not self.shader_program or not self.deck:
-        #     return
-            
-        # # Get texture from deck
-        # texture_id = self.deck.get_texture()
-        
-        # if texture_id and texture_id > 0:
-        #     glUseProgram(self.shader_program)
-        #     glActiveTexture(GL_TEXTURE0)
-        #     glBindTexture(GL_TEXTURE_2D, texture_id)
-        #     glUniform1i(glGetUniformLocation(self.shader_program, "screenTexture"), 0)
+        if not self.shader_program or not self.deck:
+            return
 
-        #     glBindVertexArray(self.quad_vao)
-        #     glDrawArrays(GL_TRIANGLES, 0, 6)
-        #     glBindVertexArray(0)
-        #     glUseProgram(0)
-        # else:
-        #     # Draw a fallback pattern if no texture
-        #     glClearColor(0.1, 0.1, 0.2, 1.0)
-        #     glClear(GL_COLOR_BUFFER_BIT)
+        # Get texture from deck and draw it to the quad
+        texture_id = self.deck.get_texture()
+
+        if texture_id and texture_id > 0:
+            glUseProgram(self.shader_program)
+            glActiveTexture(GL_TEXTURE0)
+            glBindTexture(GL_TEXTURE_2D, texture_id)
+            glUniform1i(glGetUniformLocation(self.shader_program, "screenTexture"), 0)
+
+            glBindVertexArray(self.quad_vao)
+            glDrawArrays(GL_TRIANGLES, 0, 6)
+            glBindVertexArray(0)
+            glUseProgram(0)
+        else:
+            # Draw a fallback pattern if no texture
+            glClearColor(0.1, 0.1, 0.2, 1.0)
+            glClear(GL_COLOR_BUFFER_BIT)
 
     def update_preview(self):
         self.update()

--- a/visuals/deck.py
+++ b/visuals/deck.py
@@ -86,9 +86,9 @@ class Deck:
                 self._gl_initialized = True
                 logging.debug(f"Visualizer {self.visualizer_name} initialization completed")
 
-            # Set viewport and clear
+            # Set viewport and clear with transparent background
             glViewport(0, 0, self.size.width(), self.size.height())
-            glClearColor(0.0, 0.0, 0.0, 1.0)
+            glClearColor(0.0, 0.0, 0.0, 0.0)
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
             
             # Paint the visualizer


### PR DESCRIPTION
## Summary
- Re-enable deck preview windows and update previews regularly
- Restore texture-based rendering in `PreviewGLWidget`
- Use transparent framebuffer clearing in deck rendering

## Testing
- `python -m py_compile ui/preview_gl_widget.py ui/control_panel_window.py visuals/deck.py`


------
https://chatgpt.com/codex/tasks/task_e_689cd12f0498833394bc463cb19e8f97