### PR TITLE
Fix BPM signal and ensure control panel initializes

### DIFF
--- a/ui/control_panel_window.py
+++ b/ui/control_panel_window.py
@@ -208,9 +208,6 @@ class ControlPanelWindow(QMainWindow):
                 # Store reference
                 self.preset_selectors[deck_id] = selector
                 
-                # Apply initial selection with delay
-                QTimer.singleShot(500, lambda: self.apply_initial_visualizer(deck_id, selector.currentText()))
-                
             else:
                 selector.addItem("No visualizers available")
                 logging.warning("No visualizers found!")
@@ -254,6 +251,9 @@ class ControlPanelWindow(QMainWindow):
 
         # Store reference to controls layout
         self.controls_layouts[deck_id] = controls_layout
+
+        # Apply initial selection with delay (after layout is ready)
+        QTimer.singleShot(500, lambda: self.apply_initial_visualizer(deck_id, selector.currentText()))
 
         return deck_frame
 

--- a/ui/main_application.py
+++ b/ui/main_application.py
@@ -177,7 +177,7 @@ class MainApplication:
             if hasattr(self.midi_engine, 'device_disconnected'):
                 self.midi_engine.device_disconnected.connect(self.on_midi_device_disconnected)
             if hasattr(self.midi_engine, 'bpm_changed'):
-                self.midi_engine.bmp_changed.connect(self.on_bpm_changed)
+                self.midi_engine.bpm_changed.connect(self.on_bpm_changed)
             
             logging.info("✅ MIDI connections established")
             


### PR DESCRIPTION
## Summary
- Fix typo in MIDI engine BPM signal connection
- Initialize control panel deck layouts before scheduling visualizer load to prevent missing controls

## Testing
- `pytest -q` *(fails: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_689e2d485cac83338e74f20506bfbdd5