### PR TITLE
Reset OpenGL state to render visualizers independently

### DIFF
--- a/ui/mixer_window.py
+++ b/ui/mixer_window.py
@@ -288,10 +288,14 @@ class MixerWindow(QMainWindow):
             # Now composite them in the main framebuffer
             glBindFramebuffer(GL_FRAMEBUFFER, self.gl_widget.defaultFramebufferObject())
             glViewport(0, 0, self.gl_widget.width(), self.gl_widget.height())
-            
-            # Clear main framebuffer
+
+            # Clear main framebuffer and reset state that might be changed by visualizers
+            glDisable(GL_DEPTH_TEST)
+            glDisable(GL_CULL_FACE)
+            glDepthMask(GL_FALSE)
             glClearColor(0.0, 0.0, 0.0, 1.0)
-            glClear(GL_COLOR_BUFFER_BIT)
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+            glDepthMask(GL_TRUE)
 
             if not self.shader_program or not self.quad_vao:
                 return

--- a/visuals/deck.py
+++ b/visuals/deck.py
@@ -157,17 +157,25 @@ class Deck:
                         try:
                             # Paint visualizer directly without deprecated state saving
                             self.visualizer.paintGL()
-                            
+
                             self._frame_count += 1
                             if self._frame_count % 300 == 0:
                                 logging.debug(f"🎬 Deck {self.deck_id}: {self.visualizer_name} - Frame {self._frame_count}")
-                                
+
                         except Exception as e:
                             current_time = time.time()
                             if current_time - self._last_error_log > 5.0:
                                 logging.error(f"❌ Deck {self.deck_id}: Error in paintGL: {e}")
                                 self._last_error_log = current_time
                             self._render_fallback()
+                        finally:
+                            # Reset GL state changed by visualizers
+                            try:
+                                glUseProgram(0)
+                                glDisable(GL_DEPTH_TEST)
+                                glDisable(GL_CULL_FACE)
+                            except Exception:
+                                pass
                 else:
                     self._render_fallback()
                 


### PR DESCRIPTION
## Summary
- Clear depth buffer and disable depth/cull state before compositing deck textures
- Reset GL program and depth/cull flags after each deck visualizer render to prevent state bleed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_689e3409016883338d0c38617b819877