### PR TITLE
refactor: unify midi editor and fix mappings

### DIFF
--- a/config/midi_mappings.json
+++ b/config/midi_mappings.json
@@ -1,461 +1,254 @@
 {
-    "deck_a_preset_0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Simple Test",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note36"
+  "deck_a_preset_0": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Simple Test",
+      "custom_values": ""
     },
-    "deck_a_preset_1": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Intro Background",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note37"
+    "midi": "note_on_ch0_note36"
+  },
+  "deck_a_preset_1": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Wire Terrain",
+      "custom_values": ""
     },
-    "deck_a_preset_2": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Intro Text ROBOTICA",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note38"
+    "midi": "note_on_ch0_note37"
+  },
+  "deck_a_preset_2": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Abstract Lines",
+      "custom_values": ""
     },
-    "deck_a_preset_3": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Wire Terrain",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note39"
+    "midi": "note_on_ch0_note38"
+  },
+  "deck_a_preset_3": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Geometric Particles",
+      "custom_values": ""
     },
-    "deck_a_preset_4": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Abstract Lines",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note40"
+    "midi": "note_on_ch0_note39"
+  },
+  "deck_a_preset_4": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Evolutive Particles",
+      "custom_values": ""
     },
-    "deck_a_preset_5": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Geometric Particles",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note41"
+    "midi": "note_on_ch0_note40"
+  },
+  "deck_a_preset_5": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Abstract Shapes",
+      "custom_values": ""
     },
-    "deck_a_preset_6": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Evolutive Particles",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note42"
+    "midi": "note_on_ch0_note41"
+  },
+  "deck_a_preset_6": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Mobius Band",
+      "custom_values": ""
     },
-    "deck_a_preset_7": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Abstract Shapes",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note43"
+    "midi": "note_on_ch0_note42"
+  },
+  "deck_a_preset_7": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Building Madness",
+      "custom_values": ""
     },
-    "deck_a_preset_8": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Mobius Band",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note44"
+    "midi": "note_on_ch0_note43"
+  },
+  "deck_a_preset_8": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Cosmic Flow",
+      "custom_values": ""
     },
-    "deck_a_preset_9": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Building Madness",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note45"
+    "midi": "note_on_ch0_note44"
+  },
+  "deck_a_preset_9": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Fluid Particles",
+      "custom_values": ""
     },
-    "deck_a_clear": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": null,
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note46"
+    "midi": "note_on_ch0_note45"
+  },
+  "deck_a_clear": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": null,
+      "custom_values": ""
     },
-    "mix_action_0": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "10s",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note48"
+    "midi": "note_on_ch0_note46"
+  },
+  "mix_action_0": {
+    "type": "crossfade_action",
+    "params": {
+      "preset": "A to B",
+      "duration": "10s",
+      "target": "Visual Mix"
     },
-    "mix_action_1": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "B to A",
-            "duration": "10s",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note49"
+    "midi": "note_on_ch0_note48"
+  },
+  "mix_action_1": {
+    "type": "crossfade_action",
+    "params": {
+      "preset": "B to A",
+      "duration": "10s",
+      "target": "Visual Mix"
     },
-    "mix_action_2": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "5s",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note50"
+    "midi": "note_on_ch0_note49"
+  },
+  "mix_action_2": {
+    "type": "crossfade_action",
+    "params": {
+      "preset": "A to B",
+      "duration": "5s",
+      "target": "Visual Mix"
     },
-    "mix_action_3": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "B to A",
-            "duration": "5s",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note51"
+    "midi": "note_on_ch0_note50"
+  },
+  "mix_action_3": {
+    "type": "crossfade_action",
+    "params": {
+      "preset": "B to A",
+      "duration": "5s",
+      "target": "Visual Mix"
     },
-    "mix_action_4": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "500ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note52"
+    "midi": "note_on_ch0_note51"
+  },
+  "mix_action_4": {
+    "type": "crossfade_action",
+    "params": {
+      "preset": "A to B",
+      "duration": "500ms",
+      "target": "Visual Mix"
     },
-    "mix_action_5": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "B to A",
-            "duration": "500ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note53"
+    "midi": "note_on_ch0_note52"
+  },
+  "mix_action_5": {
+    "type": "crossfade_action",
+    "params": {
+      "preset": "B to A",
+      "duration": "500ms",
+      "target": "Visual Mix"
     },
-    "mix_action_6": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "Instant A",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note54"
+    "midi": "note_on_ch0_note53"
+  },
+  "deck_b_preset_0": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Simple Test",
+      "custom_values": ""
     },
-    "mix_action_7": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "Instant B",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note55"
+    "midi": "note_on_ch0_note54"
+  },
+  "deck_b_preset_1": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Wire Terrain",
+      "custom_values": ""
     },
-    "mix_action_8": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "Cut to Center",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note56"
+    "midi": "note_on_ch0_note55"
+  },
+  "deck_b_preset_2": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Abstract Lines",
+      "custom_values": ""
     },
-    "note_60_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "Simple Test",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note60"
+    "midi": "note_on_ch0_note56"
+  },
+  "deck_b_preset_3": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Geometric Particles",
+      "custom_values": ""
     },
-    "note_61_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note61"
+    "midi": "note_on_ch0_note57"
+  },
+  "deck_b_preset_4": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Evolutive Particles",
+      "custom_values": ""
     },
-    "note_62_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "Intro Text ROBOTICA",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note62"
+    "midi": "note_on_ch0_note58"
+  },
+  "deck_b_preset_5": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Abstract Shapes",
+      "custom_values": ""
     },
-    "note_63_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "Wire Terrain",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note63"
+    "midi": "note_on_ch0_note59"
+  },
+  "deck_b_preset_6": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Mobius Band",
+      "custom_values": ""
     },
-    "note_64_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "Abstract Lines",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note64"
+    "midi": "note_on_ch0_note60"
+  },
+  "deck_b_preset_7": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Building Madness",
+      "custom_values": ""
     },
-    "note_65_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "Geometric Particles",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note65"
+    "midi": "note_on_ch0_note61"
+  },
+  "deck_b_preset_8": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Cosmic Flow",
+      "custom_values": ""
     },
-    "note_66_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "Evolutive Particles",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note66"
+    "midi": "note_on_ch0_note62"
+  },
+  "deck_b_preset_9": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Fluid Particles",
+      "custom_values": ""
     },
-    "note_67_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "Abstract Shapes",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note67"
+    "midi": "note_on_ch0_note63"
+  },
+  "deck_b_clear": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": null,
+      "custom_values": ""
     },
-    "note_68_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "Mobius Band",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note68"
-    },
-    "note_69_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "Building Madness",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note69"
-    },
-    "note_70_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "B",
-            "preset_name": "",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note70"
-    },
-    "note_36_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Simple Test",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note36"
-    },
-    "note_37_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Intro Text ROBOTICA",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note37"
-    },
-    "note_38_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Intro Text ROBOTICA",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note38"
-    },
-    "note_39_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Wire Terrain",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note39"
-    },
-    "note_40_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Abstract Lines",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note40"
-    },
-    "note_41_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Geometric Particles",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note41"
-    },
-    "note_42_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Evolutive Particles",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note42"
-    },
-    "note_43_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Abstract Shapes",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note43"
-    },
-    "note_44_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Mobius Band",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note44"
-    },
-    "note_45_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "Building Madness",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note45"
-    },
-    "note_46_ch0": {
-        "type": "load_preset",
-        "params": {
-            "deck_id": "A",
-            "preset_name": "",
-            "custom_values": ""
-        },
-        "midi": "note_on_ch0_note46"
-    },
-    "note_48_ch0": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note48"
-    },
-    "note_49_ch0": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note49"
-    },
-    "note_50_ch0": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note50"
-    },
-    "note_51_ch0": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note51"
-    },
-    "note_52_ch0": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note52"
-    },
-    "note_53_ch0": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note53"
-    },
-    "note_54_ch0": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note54"
-    },
-    "note_55_ch0": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note55"
-    },
-    "note_56_ch0": {
-        "type": "crossfade_action",
-        "params": {
-            "preset": "A to B",
-            "duration": "50ms",
-            "target": "Visual Mix"
-        },
-        "midi": "note_on_ch0_note56"
-    }
+    "midi": "note_on_ch0_note64"
+  }
 }

--- a/ui/midi_config_widget.py
+++ b/ui/midi_config_widget.py
@@ -42,20 +42,16 @@ class MidiConfigWidget(QWidget):
         
         # Tabs principales
         tabs = QTabWidget()
-        
-        # Tab 1: Configuración rápida por notas
-        quick_tab = self.create_quick_config_tab()
-        tabs.addTab(quick_tab, "🎹 Configuración Rápida")
-        
-        # Tab 2: Editor avanzado
+
+        # Editor único que muestra todos los mappings
         advanced_tab = self.create_advanced_tab()
-        tabs.addTab(advanced_tab, "⚙️ Editor Avanzado")
-        
-        # Tab 3: Configuración de canales
+        tabs.addTab(advanced_tab, "🎛️ Editor MIDI")
+
+        # Tab 2: Configuración de canales
         channels_tab = self.create_channels_tab()
         tabs.addTab(channels_tab, "📡 Canales MIDI")
-        
-        # Tab 4: Importar/Exportar
+
+        # Tab 3: Importar/Exportar
         import_export_tab = self.create_import_export_tab()
         tabs.addTab(import_export_tab, "💾 Importar/Exportar")
         
@@ -839,7 +835,6 @@ class MidiConfigWidget(QWidget):
     def load_current_mappings(self):
         """Cargar mappings actuales"""
         try:
-            self.update_notes_table()
             self.update_advanced_table()
             self.update_mappings_info()
         except Exception as e:


### PR DESCRIPTION
## Summary
- regenerate MIDI mappings without duplicates and cover notes 36-64
- merge MIDI editor tabs into single "Editor MIDI"

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68a06426554c83338b0b8143783448f2