### PR TITLE
Fix indentation in Intro Background visualizer

### DIFF
--- a/visuals/presets/intro_background.py
+++ b/visuals/presets/intro_background.py
@@ -468,10 +468,11 @@ class IntroBackgroundVisualizer(BaseVisualizer):
             
         except Exception as e:
             # Only log errors occasionally to avoid spam
-            if not hasattr(self, '_last_error_time') or time.time() - self._last_error_time > 5:
-            logging.error(f"IntroBackground paint error: {e}")
+            if not hasattr(self, '_last_error_time') or \
+               time.time() - self._last_error_time > 5:
+                logging.error(f"IntroBackground paint error: {e}")
                 self._last_error_time = time.time()
-            
+
             # Fallback rendering
             glClearColor(0.0, 0.0, 0.0, 1.0)
             glClear(GL_COLOR_BUFFER_BIT)


### PR DESCRIPTION
## Summary
- Properly indent error logging in `IntroBackgroundVisualizer.paintGL` to avoid syntax errors during import

## Testing
- `python -m py_compile visuals/presets/intro_background.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install numpy PyQt6 PyOpenGL` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a06e896818833395f5ab060798c4d7