### PR TITLE
Integrate new oneshot presets into MIDI mappings

### DIFF
--- a/config/midi_mappings.json
+++ b/config/midi_mappings.json
@@ -376,5 +376,41 @@
       "custom_values": ""
     },
     "midi": "note_on_ch0_note77"
+  },
+  "deck_a_preset_17": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Oneshot Circuit Signal",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note78"
+  },
+  "deck_a_preset_18": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Oneshot Electric Boom",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note79"
+  },
+  "deck_b_preset_17": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Oneshot Circuit Signal",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note80"
+  },
+  "deck_b_preset_18": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Oneshot Electric Boom",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note81"
   }
 }

--- a/config/settings.json
+++ b/config/settings.json
@@ -536,6 +536,42 @@
                 "custom_values": ""
             },
             "midi": "note_on_ch0_note77"
+        },
+        "deck_a_preset_17": {
+            "type": "load_preset",
+            "params": {
+                "deck_id": "A",
+                "preset_name": "Oneshot Circuit Signal",
+                "custom_values": ""
+            },
+            "midi": "note_on_ch0_note78"
+        },
+        "deck_a_preset_18": {
+            "type": "load_preset",
+            "params": {
+                "deck_id": "A",
+                "preset_name": "Oneshot Electric Boom",
+                "custom_values": ""
+            },
+            "midi": "note_on_ch0_note79"
+        },
+        "deck_b_preset_17": {
+            "type": "load_preset",
+            "params": {
+                "deck_id": "B",
+                "preset_name": "Oneshot Circuit Signal",
+                "custom_values": ""
+            },
+            "midi": "note_on_ch0_note80"
+        },
+        "deck_b_preset_18": {
+            "type": "load_preset",
+            "params": {
+                "deck_id": "B",
+                "preset_name": "Oneshot Electric Boom",
+                "custom_values": ""
+            },
+            "midi": "note_on_ch0_note81"
         }
     }
 }

--- a/midi_mappings.json
+++ b/midi_mappings.json
@@ -376,5 +376,41 @@
       "custom_values": ""
     },
     "midi": "note_on_ch0_note77"
+  },
+  "deck_a_preset_17": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Oneshot Circuit Signal",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note78"
+  },
+  "deck_a_preset_18": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "A",
+      "preset_name": "Oneshot Electric Boom",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note79"
+  },
+  "deck_b_preset_17": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Oneshot Circuit Signal",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note80"
+  },
+  "deck_b_preset_18": {
+    "type": "load_preset",
+    "params": {
+      "deck_id": "B",
+      "preset_name": "Oneshot Electric Boom",
+      "custom_values": ""
+    },
+    "midi": "note_on_ch0_note81"
   }
 }

--- a/midi_mappings.txt
+++ b/midi_mappings.txt
@@ -1,6 +1,6 @@
 === CONFIGURACIÓN MIDI MAPPINGS ===
 
-Total mappings: 42
+Total mappings: 46
 Fecha: 2025-08-16 13:45:50
 
 === PRESET MAPPINGS ===
@@ -40,6 +40,10 @@ Fecha: 2025-08-16 13:45:50
   note_on_ch0_note75 -> Deck A: Oneshot Boom Explosion
   note_on_ch0_note76 -> Deck B: Oneshot Character Train
   note_on_ch0_note77 -> Deck B: Oneshot Boom Explosion
+  note_on_ch0_note78 -> Deck A: Oneshot Circuit Signal
+  note_on_ch0_note79 -> Deck A: Oneshot Electric Boom
+  note_on_ch0_note80 -> Deck B: Oneshot Circuit Signal
+  note_on_ch0_note81 -> Deck B: Oneshot Electric Boom
 
 === MIX ACTIONS ===
   note_on_ch0_note48 -> A to B (10s)

--- a/visuals/visualizer_manager.py
+++ b/visuals/visualizer_manager.py
@@ -37,6 +37,8 @@ class VisualizerManager:
                 'science_analyzer',
                 'oneshot_charactertrain',
                 'oneshot_boomexplosion',
+                'oneshot_circuit_signal',
+                'oneshot_electric_boom',
             ]
             
             loaded_count = 0


### PR DESCRIPTION
## Summary
- map new Oneshot Circuit Signal and Oneshot Electric Boom presets to unique MIDI notes for both decks
- expose the new presets in config files and human-readable mapping list
- load the new oneshot presets in the visualizer manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68a09f91e8c483338b822f4acf8bfb29