### PR TITLE
Improve GPU detection and add mix reset mapping

### DIFF
--- a/config/midi_mappings.json
+++ b/config/midi_mappings.json
@@ -412,5 +412,14 @@
       "custom_values": ""
     },
     "midi": "note_on_ch0_note81"
+  },
+  "mix_action_9": {
+    "type": "crossfade_action",
+    "params": {
+      "preset": "Reset Mix",
+      "duration": "50ms",
+      "target": "Visual Mix"
+    },
+    "midi": "note_on_ch0_note57"
   }
 }

--- a/config/settings.json
+++ b/config/settings.json
@@ -222,6 +222,15 @@
             },
             "midi": "note_on_ch0_note56"
         },
+        "mix_action_9": {
+            "type": "crossfade_action",
+            "params": {
+                "preset": "Reset Mix",
+                "duration": "50ms",
+                "target": "Visual Mix"
+            },
+            "midi": "note_on_ch0_note57"
+        },
         "note_60_ch0": {
             "type": "load_preset",
             "params": {

--- a/midi/midi_engine.py
+++ b/midi/midi_engine.py
@@ -649,6 +649,9 @@ class MidiEngine(QObject):
             elif preset == "Cut to Center":
                 target_value = 0.5
                 duration_ms = 50
+            elif preset == "Reset Mix":
+                target_value = 0.5
+                duration_ms = 50
             elif preset == "A to B":
                 target_value = 1.0
             elif preset == "B to A":

--- a/midi/midi_visual_mapper.py
+++ b/midi/midi_visual_mapper.py
@@ -90,7 +90,8 @@ class MidiVisualMapper:
                     {"preset": "B to A", "duration": "500ms"},
                     {"preset": "Instant A", "duration": "50ms"},
                     {"preset": "Instant B", "duration": "50ms"},
-                    {"preset": "Cut to Center", "duration": "50ms"}
+                    {"preset": "Cut to Center", "duration": "50ms"},
+                    {"preset": "Reset Mix", "duration": "50ms"}
                 ]
             }
         }

--- a/midi/visual_mappings_config.json
+++ b/midi/visual_mappings_config.json
@@ -65,6 +65,10 @@
       {
         "preset": "Cut to Center",
         "duration": "50ms"
+      },
+      {
+        "preset": "Reset Mix",
+        "duration": "50ms"
       }
     ]
   }

--- a/ui/midi_config_widget.py
+++ b/ui/midi_config_widget.py
@@ -534,9 +534,9 @@ class MidiConfigWidget(QWidget):
                 preset_combo.addItem("-- Seleccionar Acción --")
                 crossfade_actions = [
                     "A to B (10s)", "B to A (10s)",
-                    "A to B (5s)", "B to A (5s)", 
+                    "A to B (5s)", "B to A (5s)",
                     "A to B (500ms)", "B to A (500ms)",
-                    "Instant A", "Instant B", "Cut to Center"
+                    "Instant A", "Instant B", "Cut to Center", "Reset Mix"
                 ]
                 for action in crossfade_actions:
                     preset_combo.addItem(action)
@@ -622,6 +622,8 @@ class MidiConfigWidget(QWidget):
                     preset = "Instant B"
                 elif "Cut to Center" in preset_text:
                     preset = "Cut to Center"
+                elif "Reset Mix" in preset_text:
+                    preset = "Reset Mix"
                 else:
                     preset = "A to B"
                 

--- a/ui/midi_mapping_dialog.py
+++ b/ui/midi_mapping_dialog.py
@@ -254,7 +254,7 @@ class MidiMappingDialog(QDialog):
                 "description": "Carga un preset visual en un deck"
             },
             "Mix Fader": {
-                "presets": ["A to B", "B to A", "Cut to Center", "Instant A", "Instant B"],
+                "presets": ["A to B", "B to A", "Cut to Center", "Instant A", "Instant B", "Reset Mix"],
                 "targets": ["Visual Mix"],
                 "values_template": "duration:5s",
                 "description": "Controla el crossfader/mezclador"

--- a/ui/preferences_dialog.py
+++ b/ui/preferences_dialog.py
@@ -155,19 +155,21 @@ class PreferencesDialog(QDialog):
         self.gpu_selector.clear()
         try:
             import moderngl
-            # Attempt to detect up to 4 GPUs
-            for i in range(4):
+            index = 0
+            # Try to create contexts sequentially until it fails
+            while True:
                 try:
                     ctx = moderngl.create_context(
-                        standalone=True, backend="egl", require=330, device_index=i
+                        standalone=True, require=330, device_index=index
                     )
-                    name = ctx.info.get("GL_RENDERER", f"GPU {i}")
+                    name = ctx.info.get("GL_RENDERER", f"GPU {index}")
                     ctx.release()
                     self.gpu_selector.addItem(name)
+                    index += 1
                 except Exception:
-                    if i == 0 and self.gpu_selector.count() == 0:
-                        self.gpu_selector.addItem("Default GPU")
                     break
+            if self.gpu_selector.count() == 0:
+                self.gpu_selector.addItem("Default GPU")
         except Exception:
             self.gpu_selector.addItem("Default GPU")
 


### PR DESCRIPTION
## Summary
- detect all available GPUs without forcing EGL backend for broader compatibility
- add "Reset Mix" crossfade action mapped to MIDI note 57
- expose the new action in MIDI configuration dialogs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'OpenGL')*
- `python -m py_compile ui/preferences_dialog.py ui/midi_config_widget.py ui/midi_mapping_dialog.py midi/midi_engine.py midi/midi_visual_mapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0b459a5a48333b4f8cd3971bd6e0b