### PR TITLE
Improve GPU detection in preferences

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ numpy
 scipy
 pyaudio>=0.2.11
 moderngl
+gputil


### PR DESCRIPTION
## Summary
- Enhance GPU selector to detect devices with GPUtil and fall back to moderngl probing
- Store real device indices so visuals use the chosen GPU
- Add GPUtil to requirements

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pygame-ce; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b7b25d88833399e3daceb6323af5