### PR TITLE
Fix multisample FBO handling and smooth abstract lines preset

### DIFF
--- a/visuals/deck.py
+++ b/visuals/deck.py
@@ -368,12 +368,19 @@ class Deck:
                     logging.error(f"❌ Deck {self.deck_id}: Failed to create valid FBO")
                     self.fbo = None
                 else:
-                    logging.debug(f"✅ Deck {self.deck_id}: Created FBO {self.size.width()}x{self.size.height()}, Texture: {self.fbo.texture()}")
-                    # Ensure linear filtering to avoid pixelated output when scaled
-                    glBindTexture(GL_TEXTURE_2D, self.fbo.texture())
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
-                    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
-                    glBindTexture(GL_TEXTURE_2D, 0)
+                    logging.debug(
+                        f"✅ Deck {self.deck_id}: Created FBO {self.size.width()}x{self.size.height()}, Texture: {self.fbo.texture()}"
+                    )
+                    # Only apply filtering when not multisampled
+                    if fbo_format.samples() <= 1:
+                        glBindTexture(GL_TEXTURE_2D, self.fbo.texture())
+                        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
+                        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
+                        glBindTexture(GL_TEXTURE_2D, 0)
+                    else:
+                        logging.debug(
+                            f"Deck {self.deck_id}: Multisampled FBO - skipping texture filtering"
+                        )
                     self._fbo_dirty = True
                     
         except Exception as e:

--- a/visuals/presets/abstract_lines.py
+++ b/visuals/presets/abstract_lines.py
@@ -71,6 +71,8 @@ class AbstractLinesVisualizer(BaseVisualizer):
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
         glDisable(GL_DEPTH_TEST)  # Keep it simple like working ones
+        glEnable(GL_LINE_SMOOTH)
+        glHint(GL_LINE_SMOOTH_HINT, GL_NICEST)
         
         if not self.load_shaders():
             print("Failed to load shaders")

--- a/visuals/render_backend.py
+++ b/visuals/render_backend.py
@@ -7,6 +7,7 @@ import ctypes
 from OpenGL.GL import (
     GL_ARRAY_BUFFER,
     GL_BLEND,
+    GL_MULTISAMPLE,
     GL_COLOR_BUFFER_BIT,
     GL_DEPTH_BUFFER_BIT,
     GL_FALSE,


### PR DESCRIPTION
## Summary
- prevent NameError by importing `GL_MULTISAMPLE`
- avoid invalid glBindTexture calls for multisampled FBOs
- enable line smoothing in Abstract Lines preset for cleaner visuals

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68a0be578dcc83338188336fdd1c4b76