### PR TITLE
Bind program before uniform updates to avoid GL errors

### DIFF
--- a/visuals/render_backend.py
+++ b/visuals/render_backend.py
@@ -196,9 +196,18 @@ class GLBackend(RenderBackend):
         glViewport(x, y, w, h)
 
     def uniform(self, program: int, name: str, value: Any) -> None:
+        """Set a uniform value ensuring the program is bound."""
+
         loc = glGetUniformLocation(program, name)
         if loc < 0:
             return
+
+        # glUniform* calls require the program to be currently bound.
+        # Some visuals call this helper before invoking GLVertexArray.render,
+        # which binds/unbinds the program internally.  Without binding here
+        # the uniform update would raise GL_INVALID_OPERATION (1282).
+        glUseProgram(program)
+
         if isinstance(value, (float, int)):
             glUniform1f(loc, float(value))
         elif isinstance(value, (list, tuple)):


### PR DESCRIPTION
## Summary
- Ensure `GLBackend.uniform` binds shader program before calling `glUniform*`
- Prevents GL_INVALID_OPERATION errors when visuals set uniforms prior to rendering

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68a0d7003f7c83339075ca78b0804684