### PR TITLE
Fix texture checks that blocked visual output

### DIFF
--- a/ui/mixer_window.py
+++ b/ui/mixer_window.py
@@ -333,20 +333,9 @@ class MixerWindow(QMainWindow):
             deck_a_active = self.deck_a and self.deck_a.has_active_visualizer()
             deck_b_active = self.deck_b and self.deck_b.has_active_visualizer()
             
-            # Get textures from decks and verify validity
+            # Get textures from decks
             texture_a = self.deck_a.get_texture() if deck_a_active else 0
-            if texture_a and not glIsTexture(texture_a):
-                logging.debug(
-                    "Deck A provided invalid texture id %s; falling back to 0", texture_a
-                )
-                texture_a = 0
-
             texture_b = self.deck_b.get_texture() if deck_b_active else 0
-            if texture_b and not glIsTexture(texture_b):
-                logging.debug(
-                    "Deck B provided invalid texture id %s; falling back to 0", texture_b
-                )
-                texture_b = 0
 
             # Bind textures (even if 0, for shader consistency)
             glActiveTexture(GL_TEXTURE0)


### PR DESCRIPTION
## Summary
- Remove fragile glIsTexture validation in deck framebuffer creation and texture retrieval
- Simplify MixerWindow's texture binding logic

## Testing
- `pytest -q` *(fails: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68a0dd15b3448333a3277a6dfd10608e