### PR TITLE
Import GL_COMPILE_STATUS constant for GL shader compilation

### DIFF
--- a/visuals/render_backend.py
+++ b/visuals/render_backend.py
@@ -13,6 +13,7 @@ from OpenGL.GL import (
     GL_FALSE,
     GL_FLOAT,
     GL_FRAGMENT_SHADER,
+    GL_COMPILE_STATUS,
     GL_LINK_STATUS,
     GL_STATIC_DRAW,
     GL_TRIANGLES,
@@ -129,7 +130,7 @@ class GLBackend(RenderBackend):
         vs = glCreateShader(GL_VERTEX_SHADER)
         glShaderSource(vs, vertex_src)
         glCompileShader(vs)
-        if not glGetShaderiv(vs, 0x8B81):
+        if not glGetShaderiv(vs, GL_COMPILE_STATUS):
             error = glGetShaderInfoLog(vs).decode()
             glDeleteShader(vs)
             raise RuntimeError(f"Vertex shader compilation failed: {error}")
@@ -137,7 +138,7 @@ class GLBackend(RenderBackend):
         fs = glCreateShader(GL_FRAGMENT_SHADER)
         glShaderSource(fs, fragment_src)
         glCompileShader(fs)
-        if not glGetShaderiv(fs, 0x8B81):
+        if not glGetShaderiv(fs, GL_COMPILE_STATUS):
             error = glGetShaderInfoLog(fs).decode()
             glDeleteShader(vs)
             glDeleteShader(fs)


### PR DESCRIPTION
## Summary
- import `GL_COMPILE_STATUS` from OpenGL
- use the constant instead of a magic number when validating shader compilation

## Testing
- `pytest` *(fails: No module named 'PyQt6', 'moderngl', 'numpy', 'OpenGL')*

------
https://chatgpt.com/codex/tasks/task_e_68a185e140f48333be0d20941f07c58e