### PR TITLE
Fix GPU selection and backend propagation

### DIFF
--- a/ui/control_panel_window.py
+++ b/ui/control_panel_window.py
@@ -440,11 +440,11 @@ class ControlPanelWindow(QMainWindow):
             logging.error(f"Error opening preferences: {e}")
             QMessageBox.critical(self, "Error", f"Could not open preferences: {str(e)}")
 
-    def apply_gpu_selection(self, index):
+    def apply_gpu_selection(self, index, backend_type=None):
         """Forward GPU selection changes to the mixer window"""
         try:
             if self.mixer_window:
-                self.mixer_window.apply_gpu_selection(index)
+                self.mixer_window.apply_gpu_selection(index, backend_type)
         except Exception as e:
             logging.error(f"Error applying GPU selection: {e}")
 

--- a/ui/preferences_dialog.py
+++ b/ui/preferences_dialog.py
@@ -88,7 +88,7 @@ class PreferencesDialog(QDialog):
 
         self.gpu_selector = QComboBox()
         self.gpu_info = []  # Store GPU info tuples (index, name, backend)
-        # self.populate_gpu_devices()
+        self.populate_gpu_devices()
         
         # Get current GPU setting and apply it
         current_gpu_index = self.settings_manager.get_setting("visual_settings.gpu_index", 0)


### PR DESCRIPTION
## Summary
- Populate GPU list in preferences dialog on initialization
- Allow control panel to forward selected GPU and backend to mixer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install PyQt6 moderngl numpy PyOpenGL` *(fails: Could not find a version that satisfies the requirement PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_68a19333fe1c8333838ad0d79c932181