### PR TITLE
Fix GPU selection and backend propagation

### DIFF
--- a/ui/control_panel_window.py
+++ b/ui/control_panel_window.py
@@ -440,11 +440,11 @@ class ControlPanelWindow(QMainWindow):
             logging.error(f"Error opening preferences: {e}")
             QMessageBox.critical(self, "Error", f"Could not open preferences: {str(e)}")
 
-    def apply_gpu_selection(self, index):
+    def apply_gpu_selection(self, index, backend_type=None):
         """Forward GPU selection changes to the mixer window"""
         try:
             if self.mixer_window:
-                self.mixer_window.apply_gpu_selection(index)
+                self.mixer_window.apply_gpu_selection(index, backend_type)
         except Exception as e:
             logging.error(f"Error applying GPU selection: {e}")
 

--- a/ui/preferences_dialog.py
+++ b/ui/preferences_dialog.py
@@ -88,7 +88,7 @@ class PreferencesDialog(QDialog):
 
         self.gpu_selector = QComboBox()
         self.gpu_info = []  # Store GPU info tuples (index, name, backend)
-        # self.populate_gpu_devices()
+        self.populate_gpu_devices()
         
         # Get current GPU setting and apply it
         current_gpu_index = self.settings_manager.get_setting("visual_settings.gpu_index", 0)
@@ -153,29 +153,6 @@ class PreferencesDialog(QDialog):
             device_text = f"{device['name']} ({device['channels']} ch)"
             self.audio_device_selector.addItem(device_text)
 
-    def on_midi_device_changed(self, device_name):
-        """Handle MIDI device selection change"""
-        if device_name == "No Device":
-            self.midi_engine.close_input_port()
-            self.settings_manager.set_setting("last_midi_device", "")
-        else:
-            self.midi_engine.open_input_port(device_name)
-            self.settings_manager.set_setting("last_midi_device", device_name)
-
-    def on_audio_device_changed(self, device_text):
-        """Handle audio device selection change"""
-        if device_text == "No Device":
-            self.audio_analyzer.stop_analysis()
-            self.settings_manager.set_setting("audio_settings.input_device", "")
-        else:
-            # Extract device index from the text
-            devices = self.audio_analyzer.get_available_devices()
-            for i, device in enumerate(devices):
-                if device_text.startswith(device['name']):
-                    self.audio_analyzer.set_input_device(device['index'])
-                    self.audio_analyzer.start_analysis()
-                    self.settings_manager.set_setting("audio_settings.input_device", device_text)
-                    break
 
     def populate_gpu_devices(self):
         """Populate GPU selector with available GPUs using multiple detection methods."""
@@ -216,6 +193,17 @@ class PreferencesDialog(QDialog):
 
         # Remove duplicates and populate selector
         self._finalize_gpu_list()
+
+        # Restore previous selection
+        current_gpu_index = self.settings_manager.get_setting("visual_settings.gpu_index", 0)
+        current_backend = self.settings_manager.get_setting("visual_settings.backend", "OpenGL")
+        selected_row = 0
+        for i, (idx, name, backend) in enumerate(self.gpu_info):
+            if idx == current_gpu_index and backend == current_backend:
+                selected_row = i
+                break
+        if self.gpu_info:
+            self.gpu_selector.setCurrentIndex(selected_row)
 
         logging.info(f"✅ GPU detection complete. Found {len(self.gpu_info)} options")
         for i, (idx, name, backend) in enumerate(self.gpu_info):
@@ -396,9 +384,15 @@ class PreferencesDialog(QDialog):
         """Handle backend selection change"""
         self.settings_manager.set_setting("visual_settings.backend", backend_name)
         logging.info(f"🔧 Backend changed to: {backend_name}")
-        
-        # Re-populate GPU list for the new backend
+
+        # Re-populate GPU list for the new backend and reapply selection
         self.populate_gpu_devices()
+
+        if self.gpu_info:
+            row = self.gpu_selector.currentIndex()
+            device_index, _, backend = self.gpu_info[row]
+            if hasattr(self.parent(), 'apply_gpu_selection'):
+                self.parent().apply_gpu_selection(device_index, backend)
 
     def on_midi_device_changed(self, device_name):
         """Handle MIDI device selection change"""


### PR DESCRIPTION
## Summary
- Retain previously selected GPU after regenerating the list
- Apply backend changes immediately and forward selection upstream
- Remove duplicated MIDI and audio device handlers in preferences dialog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install PyQt6 moderngl numpy PyOpenGL` *(fails: Could not find a version that satisfies the requirement PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_68a19333fe1c8333838ad0d79c932181