### PR TITLE
feat: load and map visuals dynamically

### DIFF
--- a/midi/midi_visual_mapper.py
+++ b/midi/midi_visual_mapper.py
@@ -1,7 +1,6 @@
 # midi/midi_visual_mapper.py - GESTIÓN DINÁMICA DE MAPPINGS VISUALES
 import logging
 import json
-import os
 from pathlib import Path
 
 class MidiVisualMapper:
@@ -14,9 +13,12 @@ class MidiVisualMapper:
         self.visualizer_manager = visualizer_manager
         self.visual_mappings_config = {}
         self.default_channel = 0
-        
+
         # Cargar configuración de mappings
         self.load_visual_mappings_config()
+
+        # Sincronizar configuración con visuales disponibles
+        self.sync_with_available_visuals()
         
         logging.info(f"🎨 MidiVisualMapper initialized with {len(self.visual_mappings_config)} visual configs")
 
@@ -63,21 +65,7 @@ class MidiVisualMapper:
                     "clear_note": 70
                 }
             },
-            "visual_priority_order": [
-                "Simple Test",
-                "Intro Background",
-                "Intro Text ROBOTICA",
-                "Wire Terrain",
-                "Abstract Lines",
-                "Geometric Particles",
-                "Evolutive Particles",
-                "Abstract Shapes",
-                "Mobius Band",
-                "Building Madness",
-                "Cosmic Flow",
-                "Fluid Particles",
-                "Vortex Particles"
-            ],
+            "visual_priority_order": [],
             "mix_actions": {
                 "start_note": 48,  # C2
                 "end_note": 59,    # B2

--- a/midi/visual_mappings_config.json
+++ b/midi/visual_mappings_config.json
@@ -11,21 +11,7 @@
       "clear_note": 70
     }
   },
-  "visual_priority_order": [
-    "Simple Test",
-    "Intro Background",
-    "Intro Text ROBOTICA",
-    "Wire Terrain",
-    "Abstract Lines",
-    "Geometric Particles",
-    "Evolutive Particles",
-    "Abstract Shapes",
-    "Mobius Band",
-    "Building Madness",
-    "Cosmic Flow",
-    "Fluid Particles",
-    "Vortex Particles"
-  ],
+  "visual_priority_order": [],
   "mix_actions": {
     "start_note": 48,
     "end_note": 59,

--- a/ui/main_application.py
+++ b/ui/main_application.py
@@ -2,9 +2,9 @@
 import sys
 import os
 import logging
-from PyQt6.QtWidgets import QApplication, QMessageBox
-from PyQt6.QtGui import QSurfaceFormat
-from PyQt6.QtCore import QTimer
+from PyQt6.QtWidgets import QApplication, QMessageBox, QSplashScreen
+from PyQt6.QtGui import QSurfaceFormat, QPixmap
+from PyQt6.QtCore import QTimer, Qt
 
 from utils.settings_manager import SettingsManager
 from midi.midi_engine import MidiEngine
@@ -53,9 +53,19 @@ class MainApplication:
             self.app = QApplication(sys.argv)
             self.app.setApplicationName("Audio Visualizer Pro")
             self.app.setApplicationVersion("1.0")
-            
-            
-            
+
+            # Simple loading splash while initializing components
+            pixmap = QPixmap(400, 300)
+            pixmap.fill(Qt.GlobalColor.black)
+            self.splash = QSplashScreen(pixmap)
+            self.splash.showMessage(
+                "Loading visuals and mappings...",
+                Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignBottom,
+                Qt.GlobalColor.white,
+            )
+            self.splash.show()
+            self.app.processEvents()
+
             # Initialize core components
             self.initialize_components()
             
@@ -64,6 +74,9 @@ class MainApplication:
             
             # Create UI windows with proper sequencing
             self.create_windows()
+
+            # Close splash once windows are ready
+            self.splash.finish(self.mixer_window)
             
             # CRITICAL: Setup connections and references BEFORE auto-connect
             self.setup_connections()

--- a/visuals/visualizer_manager.py
+++ b/visuals/visualizer_manager.py
@@ -1,7 +1,6 @@
 # visuals/visualizer_manager.py
 import logging
 import importlib
-import os
 import sys
 from pathlib import Path
 
@@ -18,29 +17,12 @@ class VisualizerManager:
             presets_dir = current_dir / "presets"
             logging.info(f"🔍 Loading visualizers from: {presets_dir}")
             
-            # List of visualizer modules to load (in order of preference)
-            visualizer_modules = [
-                'simple_test',        # Simple test visualizer (should always work)
-                'intro_background',    # Intro background visualizer
-                'intro_text_robotica', # Intro text overlay
-                'wire_terrain',       # Wire terrain
-                'abstract_lines',     # Abstract lines
-                'geometric_particles',
-                'evolutive_particles',
-                'abstract_shapes',
-                'mobius_band',
-                'building_madness',
-                'cosmic_flow',
-                'fluid_particles',
-                'vortex_particles',
-                'kaleido_tunney',
-                'science_analyzer',
-                'plasma_clouds',
-                'oneshot_charactertrain',
-                'oneshot_boomexplosion',
-                'oneshot_circuit_signal',
-                'oneshot_electric_boom',
-            ]
+            # Dynamically collect all visualizer modules in presets directory
+            visualizer_modules = []
+            for file in sorted(presets_dir.glob("*.py")):
+                if file.name.startswith("__"):
+                    continue
+                visualizer_modules.append(file.stem)
             
             loaded_count = 0
             failed_modules = []


### PR DESCRIPTION
## Summary
- load visual presets by scanning the presets folder instead of using a hardcoded list
- sync visual mapping config with available presets and start with an empty priority list
- display a startup splash screen while visuals and mappings are prepared

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install PyQt6 moderngl numpy PyOpenGL` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a4a65c24833380cfa8f087aa416b