### PR TITLE
Fix polygon drawing in visual settings grid

### DIFF
--- a/ui/visual_settings_tab.py
+++ b/ui/visual_settings_tab.py
@@ -11,8 +11,17 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QMessageBox,
 )
-from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QIntValidator, QFont, QPixmap, QPainter, QColor, QBrush, QPen
+from PyQt6.QtCore import Qt, QPoint
+from PyQt6.QtGui import (
+    QIntValidator,
+    QFont,
+    QPixmap,
+    QPainter,
+    QColor,
+    QBrush,
+    QPen,
+    QPolygon,
+)
 
 from pathlib import Path
 import json
@@ -267,7 +276,13 @@ def create_visual_thumbnail_large(visual_name):
         painter.setBrush(QBrush(secondary_color))
         painter.drawEllipse(45, 15, 20, 20)
         painter.setBrush(QBrush(primary_color))
-        painter.drawPolygon([(20, 40), (35, 45), (30, 55), (15, 50)])
+        polygon = QPolygon([
+            QPoint(20, 40),
+            QPoint(35, 45),
+            QPoint(30, 55),
+            QPoint(15, 50),
+        ])
+        painter.drawPolygon(polygon)
     elif "fluid" in visual_name.lower() or "flow" in visual_name.lower():
         painter.setPen(QPen(primary_color, 3))
         painter.drawPath(create_wave_path())


### PR DESCRIPTION
## Summary
- Use `QPolygon` and `QPoint` for geometric visual thumbnail drawing
- Import `QPolygon` and `QPoint` to support polygon rendering without type errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install PyQt6 moderngl -q` *(fails: Could not find a version that satisfies the requirement PyQt6; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cae8b1088333a9bd6c573cb8d8ef