### PR TITLE
Handle integer MIDI mappings safely in UI components

### DIFF
--- a/create_correct_mappings.py
+++ b/create_correct_mappings.py
@@ -44,7 +44,7 @@ def create_correct_midi_mappings():
         for midi_key, expected_preset, expected_deck in critical_tests:
             found = False
             for action_id, mapping_data in mappings.items():
-                if mapping_data.get('midi') == midi_key:
+                if isinstance(mapping_data, dict) and mapping_data.get('midi') == midi_key:
                     action_type = mapping_data.get('type')
                     params = mapping_data.get('params', {})
 
@@ -70,9 +70,9 @@ def create_correct_midi_mappings():
         # Mostrar resumen por deck
         print(f"\n📋 RESUMEN POR DECK:\n")
 
-        deck_a_count = len([m for m in mappings.values() if m.get('params', {}).get('deck_id') == 'A'])
-        deck_b_count = len([m for m in mappings.values() if m.get('params', {}).get('deck_id') == 'B'])
-        mix_count = len([m for m in mappings.values() if m.get('type') == 'crossfade_action'])
+        deck_a_count = len([m for m in mappings.values() if isinstance(m, dict) and m.get('params', {}).get('deck_id') == 'A'])
+        deck_b_count = len([m for m in mappings.values() if isinstance(m, dict) and m.get('params', {}).get('deck_id') == 'B'])
+        mix_count = len([m for m in mappings.values() if isinstance(m, dict) and m.get('type') == 'crossfade_action'])
 
         print(f"   🔴 Deck A: {deck_a_count} mappings")
         print(f"   🟢 Deck B: {deck_b_count} mappings")

--- a/debug_midi_mappings.py
+++ b/debug_midi_mappings.py
@@ -36,7 +36,10 @@ def debug_midi_mappings():
                 if i >= 10:  # Mostrar solo los primeros 10
                     print(f"      ... y {len(config_mappings) - 10} más")
                     break
-                
+
+                if not isinstance(mapping_data, dict):
+                    continue
+
                 midi_key = mapping_data.get('midi', 'no_midi')
                 action_type = mapping_data.get('type', 'unknown')
                 params = mapping_data.get('params', {})
@@ -66,7 +69,7 @@ def debug_midi_mappings():
             for midi_key, expected in critical_tests:
                 found = False
                 for action_id, mapping_data in config_mappings.items():
-                    if mapping_data.get('midi') == midi_key:
+                    if isinstance(mapping_data, dict) and mapping_data.get('midi') == midi_key:
                         action_type = mapping_data.get('type', 'unknown')
                         params = mapping_data.get('params', {})
                         
@@ -115,6 +118,8 @@ def debug_midi_mappings():
                     if i >= 5:
                         print(f"      ... y {len(midi_mappings) - 5} más")
                         break
+                    if not isinstance(mapping_data, dict):
+                        continue
                     midi_key = mapping_data.get('midi', 'no_midi')
                     print(f"      {action_id}: {midi_key}")
             else:
@@ -170,7 +175,7 @@ def debug_midi_mappings():
             test_key = "note_on_ch0_note37"  # Wire Terrain Deck A
             found_mapping = None
             for action_id, mapping_data in mappings.items():
-                if mapping_data.get('midi') == test_key:
+                if isinstance(mapping_data, dict) and mapping_data.get('midi') == test_key:
                     found_mapping = (action_id, mapping_data)
                     break
             

--- a/midi_diagnostic.py
+++ b/midi_diagnostic.py
@@ -29,7 +29,7 @@ def diagnose_midi():
             key = f"note_on_ch0_note{note}"
             found = False
             for action_id, mapping_data in mappings.items():
-                if mapping_data.get('midi') == key:
+                if isinstance(mapping_data, dict) and mapping_data.get('midi') == key:
                     action_type = mapping_data.get('type', 'unknown')
                     params = mapping_data.get('params', {})
                     preset = params.get('preset_name', params.get('preset', 'N/A'))

--- a/ui/control_panel_window.py
+++ b/ui/control_panel_window.py
@@ -484,7 +484,8 @@ class ControlPanelWindow(QMainWindow):
                 test_key = f"note_on_ch0_note{note}"
                 found = False
                 for action_id, mapping_data in self.midi_engine.midi_mappings.items():
-                    if mapping_data.get('midi') == test_key:
+                    # Some mappings may be stored as simple integers; skip those
+                    if isinstance(mapping_data, dict) and mapping_data.get('midi') == test_key:
                         action_type = mapping_data.get('type', 'unknown')
                         params = mapping_data.get('params', {})
                         preset = params.get('preset_name', 'N/A')
@@ -719,11 +720,11 @@ class ControlPanelWindow(QMainWindow):
 
             deck_id = None
             if midi_key and self.midi_engine:
-                mappings = self.midi_engine.get_midi_mappings()
-                for mapping_data in mappings.values():
-                    if mapping_data.get('midi') == midi_key:
-                        deck_id = mapping_data.get('params', {}).get('deck_id')
-                        break
+                # Look up mapping information using the pre-built MIDI lookup
+                lookup_entry = getattr(self.midi_engine, 'midi_lookup', {}).get(midi_key)
+                if lookup_entry:
+                    _, mapping_data = lookup_entry
+                    deck_id = mapping_data.get('params', {}).get('deck_id')
 
             if hasattr(self, 'midi_activity_table') and not getattr(self, 'midi_monitoring_paused', False):
                 row = self.midi_activity_table.rowCount()

--- a/ui/main_application.py
+++ b/ui/main_application.py
@@ -227,20 +227,16 @@ class MainApplication:
         """Debug method to log all MIDI messages and check mappings"""
         try:
             logging.debug(f"🎹 MIDI Learning Signal: {message_key}")
-            
-            # Check if this message has a mapping
-            mappings_found = 0
-            for action_id, mapping_data in self.midi_engine.midi_mappings.items():
-                if mapping_data.get('midi') == message_key:
-                    action_type = mapping_data.get('type', 'unknown')
-                    params = mapping_data.get('params', {})
-                    logging.debug(f"🎯 Found mapping: {action_id} -> {action_type} {params}")
-                    mappings_found += 1
-            
-            if mappings_found == 0:
-                logging.debug(f"🔍 No mapping found for: {message_key}")
+
+            # Look up mapping information using the MIDI lookup table
+            mapping_entry = getattr(self.midi_engine, 'midi_lookup', {}).get(message_key)
+            if mapping_entry:
+                action_id, mapping_data = mapping_entry
+                action_type = mapping_data.get('type', 'unknown')
+                params = mapping_data.get('params', {})
+                logging.debug(f"🎯 Found mapping: {action_id} -> {action_type} {params}")
             else:
-                logging.debug(f"✅ Found {mappings_found} mapping(s) for: {message_key}")
+                logging.debug(f"🔍 No mapping found for: {message_key}")
                 
         except Exception as e:
             logging.error(f"Error in debug_midi_message: {e}")

--- a/ui/midi_config_widget.py
+++ b/ui/midi_config_widget.py
@@ -461,8 +461,10 @@ class MidiConfigWidget(QWidget):
             # Buscar mapping para esta nota
             mappings = self.midi_engine.get_midi_mappings()
             note_mapping = None
-            
+
             for action_id, mapping_data in mappings.items():
+                if not isinstance(mapping_data, dict):
+                    continue
                 midi_key = mapping_data.get('midi', '')
                 if f'note{note}' in midi_key:
                     note_mapping = mapping_data
@@ -656,8 +658,10 @@ class MidiConfigWidget(QWidget):
             # Buscar y eliminar mappings para esta nota
             mappings = self.midi_engine.get_midi_mappings()
             to_delete = []
-            
+
             for action_id, mapping_data in mappings.items():
+                if not isinstance(mapping_data, dict):
+                    continue
                 midi_key = mapping_data.get('midi', '')
                 if f'note{note}' in midi_key:
                     to_delete.append(action_id)
@@ -848,9 +852,12 @@ class MidiConfigWidget(QWidget):
             if not self.midi_engine:
                 return
                 
-            mappings = self.midi_engine.get_midi_mappings()
+            mappings = {
+                aid: m for aid, m in self.midi_engine.get_midi_mappings().items()
+                if isinstance(m, dict)
+            }
             self.advanced_table.setRowCount(len(mappings))
-            
+
             for row, (action_id, mapping_data) in enumerate(mappings.items()):
                 # ID
                 id_item = QTableWidgetItem(action_id)

--- a/ui/midi_mapping_dialog.py
+++ b/ui/midi_mapping_dialog.py
@@ -517,7 +517,7 @@ class MidiMappingDialog(QDialog):
 
             # Verificar duplicados
             for i, mapping in enumerate(self.mappings):
-                if i != self.learning_row and mapping.get('midi') == message_key:
+                if i != self.learning_row and isinstance(mapping, dict) and mapping.get('midi') == message_key:
                     result = QMessageBox.question(
                         self, "Asignación Duplicada",
                         f"El control MIDI '{message_key}' ya está asignado a la fila {i + 1}.\n"


### PR DESCRIPTION
## Summary
- Guard MIDI mapping iterations against integer entries
- Look up deck mappings using midi_lookup instead of raw mapping values
- Use lookup table in MIDI debugging for reliable mapping info

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68a1e5d3fb108333bdc6b53a71250ac7