### PR TITLE
Add default fade time control for live decks

### DIFF
--- a/ui/live_control_tab.py
+++ b/ui/live_control_tab.py
@@ -121,6 +121,7 @@ def create_improved_deck_grid(self, container):
             fade_input.setRange(0, 10000)
             fade_input.setSuffix(" ms")
             fade_input.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            fade_input.setValue(2000)
             header_layout.addWidget(fade_input)
 
             if not hasattr(self, "deck_fade_inputs"):


### PR DESCRIPTION
## Summary
- Pre-set deck fade time spin boxes to 2000 ms in the live control grid
- Ensure mixer window receives initial fade durations for each deck

## Testing
- `QT_QPA_PLATFORM=offscreen pytest` *(fails: ImportError in `visuals/presets/simple_test.py` for relative import)*

------
https://chatgpt.com/codex/tasks/task_e_68a2101c9a8c8333a7fb2ff15f1b4feb