### PR TITLE
Use visual config deck channels for MIDI lookups

### DIFF
--- a/midi/midi_engine.py
+++ b/midi/midi_engine.py
@@ -257,11 +257,15 @@ class MidiEngine(QObject):
         """Build lookup table from simple visual->note mappings."""
         self.midi_lookup = {}
         try:
+            deck_channels = self.visual_mapper.config.get("deck_channels", {})
+            if not deck_channels:
+                deck_channels = {"A": 0, "B": 1, "C": 2, "D": 3}
+
             for visual_name, note in self.midi_mappings.items():
                 if not isinstance(note, int):
                     continue
-                for deck_index, deck_id in enumerate(['A', 'B', 'C', 'D']):
-                    midi_key = f"note_on_ch{deck_index}_note{note}"
+                for deck_id, channel in deck_channels.items():
+                    midi_key = f"note_on_ch{channel}_note{note}"
                     action_id = f"{visual_name.replace(' ', '_').lower()}_{deck_id.lower()}"
                     mapping_data = {
                         'type': 'load_preset',

--- a/ui/live_control_tab.py
+++ b/ui/live_control_tab.py
@@ -89,11 +89,21 @@ def create_improved_deck_grid(self, container):
         # Sort visuals by assigned MIDI note, falling back to high value
         visuals = sorted(visuals, key=lambda v: midi_info.get(v, 9999))
 
+        deck_channels = {"A": 12, "B": 13, "C": 14, "D": 15}
+        if (
+            hasattr(self, "midi_engine")
+            and self.midi_engine
+            and getattr(self.midi_engine, "visual_mapper", None)
+        ):
+            deck_channels = self.midi_engine.visual_mapper.config.get(
+                "deck_channels", deck_channels
+            )
+
         deck_config = {
-            "A": {"channel": 13, "color": "#ff6b6b", "name": "DECK A"},
-            "B": {"channel": 14, "color": "#4ecdc4", "name": "DECK B"},
-            "C": {"channel": 15, "color": "#45b7d1", "name": "DECK C"},
-            "D": {"channel": 16, "color": "#96ceb4", "name": "DECK D"},
+            "A": {"channel": deck_channels.get("A", 0) + 1, "color": "#ff6b6b", "name": "DECK A"},
+            "B": {"channel": deck_channels.get("B", 1) + 1, "color": "#4ecdc4", "name": "DECK B"},
+            "C": {"channel": deck_channels.get("C", 2) + 1, "color": "#45b7d1", "name": "DECK C"},
+            "D": {"channel": deck_channels.get("D", 3) + 1, "color": "#96ceb4", "name": "DECK D"},
         }
 
         # Store grid info for interactions


### PR DESCRIPTION
## Summary
- Build MIDI lookup tables using configured deck channels instead of fixed A-D indices
- Populate live control grid channels from visual mapping config so UI and MIDI agree

## Testing
- `pytest` *(fails: ImportError: libGL.so.1 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a225c2b5dc8333a75dfeda31d1ccd9