### PR TITLE
Scope active visual cell border styling

### DIFF
--- a/ui/control_panel_window.py
+++ b/ui/control_panel_window.py
@@ -595,10 +595,23 @@ class ControlPanelWindow(QMainWindow):
                     cell.setStyleSheet(cell.base_style)
 
             if preset_name and preset_name in cells:
+                cell = cells[preset_name]
+                cell.setObjectName("visual-cell")
                 highlight_style = (
-                    f"QFrame {{ background-color: #1a1a1a; border: 3px solid {color}; border-radius: 8px; }}"
+                    f"QFrame#visual-cell {{\n"
+                    f"    background-color: #1a1a1a;\n"
+                    f"    border: 3px solid {color};\n"
+                    "    border-radius: 8px;\n" 
+                    "}\n"
+                    f"QFrame#visual-cell:hover {{\n"
+                    f"    border-color: {color};\n"
+                    "}\n"
+                    "QLabel {\n"
+                    "    border: none;\n"
+                    "    background: transparent;\n"
+                    "}\n"
                 )
-                cells[preset_name].setStyleSheet(highlight_style)
+                cell.setStyleSheet(highlight_style)
         except Exception as e:
             logging.error(f"Error updating grid highlight: {e}")
 


### PR DESCRIPTION
## Summary
- Ensure active visual cells use objectName-scoped stylesheet so only outer container gets border
- Remove borders from inner labels in active visual cell highlight to keep thumbnail, title and note unified

## Testing
- `python -m py_compile ui/control_panel_window.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6', No module named 'moderngl')*

------
https://chatgpt.com/codex/tasks/task_e_68a22a7747a48333b48e3bbcd6e9eddd