### PR TITLE
Add custom thumbnails and per-deck transparency sliders

### DIFF
--- a/ui/live_control_tab.py
+++ b/ui/live_control_tab.py
@@ -8,6 +8,7 @@ from PyQt6.QtWidgets import (
     QFrame,
     QPushButton,
     QSpinBox,
+    QSlider,
 )
 from PyQt6.QtCore import Qt
 
@@ -161,6 +162,36 @@ def create_improved_deck_grid(self, container):
                 except Exception as e:
                     logging.error(f"Error initializing fade input for deck {deck_id}: {e}")
 
+            opacity_slider = QSlider(Qt.Orientation.Horizontal)
+            opacity_slider.setRange(0, 100)
+            opacity_slider.setValue(100)
+            header_layout.addWidget(opacity_slider)
+
+            opacity_label = QLabel("100%")
+            opacity_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            header_layout.addWidget(opacity_label)
+
+            if not hasattr(self, "deck_opacity_sliders"):
+                self.deck_opacity_sliders = {}
+            self.deck_opacity_sliders[deck_id] = opacity_slider
+
+            if hasattr(self, "mixer_window") and self.mixer_window:
+                try:
+                    self.mixer_window.set_deck_opacity(deck_id, 1.0)
+
+                    def on_opacity_change(value, d=deck_id, lbl=opacity_label):
+                        try:
+                            lbl.setText(f"{value}%")
+                            self.mixer_window.set_deck_opacity(d, value / 100.0)
+                        except Exception as e:
+                            logging.error(f"Error setting opacity for deck {d}: {e}")
+
+                    opacity_slider.valueChanged.connect(on_opacity_change)
+                except Exception as e:
+                    logging.error(
+                        f"Error initializing opacity slider for deck {deck_id}: {e}"
+                    )
+
             grid.addWidget(header_widget, row, 0)
 
             for col, visual_name in enumerate(visuals):
@@ -217,6 +248,7 @@ def create_visual_cell(parent, deck_id, visual_name, midi_info, deck_color):
     thumb_label.setFixedSize(96, 60)
     thumb_label.setPixmap(generate_visual_thumbnail(visual_name, 96, 60))
     layout.addWidget(thumb_label)
+    cell.thumb_label = thumb_label
 
     name_label = QLabel(visual_name)
     name_label.setAlignment(Qt.AlignmentFlag.AlignCenter)

--- a/ui/mixer_window.py
+++ b/ui/mixer_window.py
@@ -207,7 +207,6 @@ class MixerWindow(QMainWindow):
             in vec2 TexCoord;
             uniform sampler2D texture1;
             uniform sampler2D texture2;
-            uniform float mixValue;
             uniform float deck_a_opacity;
             uniform float deck_b_opacity;
             uniform float global_brightness;
@@ -230,15 +229,10 @@ class MixerWindow(QMainWindow):
                     color2.rgb *= deck_b_opacity;  // Apply deck opacity
                 }
                 
-                // Mix the colors
-                vec4 mixed_color = mix(color1, color2, mixValue);
-                
-                // Apply global brightness
+                vec4 mixed_color = color1 + color2;
                 mixed_color.rgb *= global_brightness;
-                
-                // Ensure proper alpha
+                mixed_color.rgb = clamp(mixed_color.rgb, 0.0, 1.0);
                 mixed_color.a = 1.0;
-                
                 FragColor = mixed_color;
             }
             """
@@ -410,8 +404,10 @@ class MixerWindow(QMainWindow):
 
             # Debug logging
             if self.frame_count % 300 == 0:  # Every 5 seconds at 60fps
-                logging.debug(f"🎬 Frame {self.frame_count}: A_active={deck_a_active}, B_active={deck_b_active}, "
-                            f"A_tex={texture_a}, B_tex={texture_b}, mix={self.mix_value:.2f}")
+                logging.debug(
+                    f"🎬 Frame {self.frame_count}: A_active={deck_a_active}, B_active={deck_b_active}, "
+                    f"A_tex={texture_a}, B_tex={texture_b}"
+                )
 
             # Bind textures
             glActiveTexture(GL_TEXTURE0)
@@ -430,7 +426,6 @@ class MixerWindow(QMainWindow):
             try:
                 glUniform1i(glGetUniformLocation(self.shader_program, "texture1"), 0)
                 glUniform1i(glGetUniformLocation(self.shader_program, "texture2"), 1)
-                glUniform1f(glGetUniformLocation(self.shader_program, "mixValue"), self.mix_value)
                 glUniform1f(glGetUniformLocation(self.shader_program, "deck_a_opacity"), self.deck_a_opacity)
                 glUniform1f(glGetUniformLocation(self.shader_program, "deck_b_opacity"), self.deck_b_opacity)
                 glUniform1f(glGetUniformLocation(self.shader_program, "global_brightness"), self.global_brightness)


### PR DESCRIPTION
## Summary
- Allow visuals to use user-specified thumbnail images with open/remove controls in visual settings
- Add transparency sliders for each deck and remove crossfader dependency
- Mix decks by combining colors with deck opacities

## Testing
- `python -m py_compile ui/thumbnail_utils.py ui/visual_settings_tab.py ui/live_control_tab.py ui/mixer_window.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68a22ee3bb5483339580f1e6c59bd566