### PR TITLE
Enable toggled audio reactivity in visuals

### DIFF
--- a/ui/main_application.py
+++ b/ui/main_application.py
@@ -154,7 +154,11 @@ class MainApplication:
             logging.info("🖥️ Creating UI windows...")
             
             # Create mixer window first
-            self.mixer_window = MixerWindow(self.visualizer_manager, self.settings_manager)
+            self.mixer_window = MixerWindow(
+                self.visualizer_manager,
+                self.settings_manager,
+                self.audio_analyzer,
+            )
             logging.info("✅ Mixer window created")
             
             # Create control panel (rediseñado para operación MIDI)

--- a/ui/mixer_window.py
+++ b/ui/mixer_window.py
@@ -12,6 +12,7 @@ from OpenGL.GL import *
 from visuals.deck import Deck
 from opengl_fixes import OpenGLSafety
 
+
 class MixerWindow(QMainWindow):
     # Custom signals for thread-safe communication
     signal_set_mix_value = pyqtSignal(int)
@@ -20,12 +21,13 @@ class MixerWindow(QMainWindow):
     signal_set_deck_opacity = pyqtSignal(str, float)
     signal_trigger_deck_action = pyqtSignal(str, str)
 
-    def __init__(self, visualizer_manager, settings_manager=None):
+    def __init__(self, visualizer_manager, settings_manager=None, audio_analyzer=None):
         super().__init__()
         self.setWindowTitle("Audio Visualizer Pro - Main Output")
         self.setGeometry(100, 100, 800, 600)
         self.visualizer_manager = visualizer_manager
         self.settings_manager = settings_manager
+        self.audio_analyzer = audio_analyzer
 
         # Thread safety
         self._mutex = QMutex()
@@ -132,16 +134,18 @@ class MixerWindow(QMainWindow):
 
                 # Create decks
                 self.deck_a = Deck(
-                    self.visualizer_manager, 
-                    "A", 
+                    self.visualizer_manager,
+                    "A",
                     gpu_index=gpu_index,
-                    use_moderngl=use_moderngl
+                    use_moderngl=use_moderngl,
+                    audio_analyzer=self.audio_analyzer,
                 )
                 self.deck_b = Deck(
-                    self.visualizer_manager, 
-                    "B", 
+                    self.visualizer_manager,
+                    "B",
                     gpu_index=gpu_index,
-                    use_moderngl=use_moderngl
+                    use_moderngl=use_moderngl,
+                    audio_analyzer=self.audio_analyzer,
                 )
                 
                 # Initialize deck FBOs

--- a/visuals/base_visualizer.py
+++ b/visuals/base_visualizer.py
@@ -1,4 +1,7 @@
 import logging
+from typing import Optional
+
+import numpy as np
 from OpenGL.GL import glGetError, GL_NO_ERROR
 from OpenGL.GLU import gluErrorString
 
@@ -9,7 +12,10 @@ class BaseVisualizer:
     def __init__(self, *args, **kwargs):
         # Accept any arguments to prevent constructor errors
         # Pure Python class, presets may extend this.
-        pass
+        self.analyzer: Optional[object] = None
+        self.audio_level: float = 0.0
+        self.audio_fft: np.ndarray = np.array([])
+        self.audio_reactive: bool = True
 
     def _check_gl_error(self, context: str = ""):
         """Checks for OpenGL errors and logs them."""
@@ -37,12 +43,73 @@ class BaseVisualizer:
 
     def cleanup(self):
         """Clean up OpenGL resources."""
-        pass
+        self.set_audio_analyzer(None)
 
     def get_controls(self):
         """Return dictionary of available controls for this visualizer"""
-        return {}
+        return {
+            "Audio Reactive": {
+                "type": "checkbox",
+                "value": self.audio_reactive,
+            }
+        }
 
     def update_control(self, name, value):
         """Update a control parameter"""
-        pass
+        if name == "Audio Reactive":
+            self.audio_reactive = bool(value)
+            return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Audio handling
+    # ------------------------------------------------------------------
+    def set_audio_analyzer(self, analyzer: Optional[object]):
+        """Attach an audio analyzer to this visualizer.
+
+        The analyzer is expected to expose ``fft_data_ready`` and
+        ``level_changed`` Qt signals as provided by ``AudioAnalyzer``.
+        """
+        if self.analyzer is analyzer:
+            return
+
+        # Disconnect from previous analyzer
+        if self.analyzer:
+            try:
+                if hasattr(self.analyzer, "fft_data_ready"):
+                    self.analyzer.fft_data_ready.disconnect(self._on_fft_data)
+                if hasattr(self.analyzer, "level_changed"):
+                    self.analyzer.level_changed.disconnect(self._on_level_changed)
+            except Exception:
+                pass
+
+        self.analyzer = analyzer
+
+        if analyzer:
+            if hasattr(analyzer, "fft_data_ready"):
+                analyzer.fft_data_ready.connect(self._on_fft_data)
+            if hasattr(analyzer, "level_changed"):
+                analyzer.level_changed.connect(self._on_level_changed)
+
+    def _on_fft_data(self, fft: np.ndarray):
+        """Store latest FFT data from audio analyzer."""
+        self.audio_fft = np.array(fft, copy=True)
+
+    def _on_level_changed(self, level: float):
+        """Store latest overall audio level."""
+        self.audio_level = float(level)
+
+    def get_frequency_bands(self, bands: int = 3) -> np.ndarray:
+        """Return smoothed frequency band values (0-100 range)."""
+        if self.analyzer and hasattr(self.analyzer, "get_frequency_bands"):
+            try:
+                return self.analyzer.get_frequency_bands(bands)
+            except Exception:
+                return np.zeros(bands)
+        return np.zeros(bands)
+
+    def get_audio_bands(self, bands: int = 3) -> np.ndarray:
+        """Return normalized frequency bands (0-1) when audio reactivity is enabled."""
+        if not self.audio_reactive:
+            return np.zeros(bands)
+        return self.get_frequency_bands(bands) / 100.0

--- a/visuals/deck.py
+++ b/visuals/deck.py
@@ -18,6 +18,7 @@ class Deck:
         gpu_index=0,
         use_moderngl=None,  # Changed to None for auto-detection
         use_post=False,
+        audio_analyzer=None,
     ):
         self.visualizer_manager = visualizer_manager
         self.deck_id = deck_id  # For debugging
@@ -52,6 +53,9 @@ class Deck:
         
         # Controls cache
         self.controls = {}
+
+        # Audio analyzer reference
+        self.audio_analyzer = audio_analyzer
 
         # Backend selection logic - FIXED
         if use_moderngl is None:
@@ -298,6 +302,10 @@ class Deck:
                     self.current_visualizer = visualizer_class()
                     self._gl_initialized = False
                     self._fbo_dirty = True
+
+                    # Pass audio analyzer to visualizer if supported
+                    if self.audio_analyzer and hasattr(self.current_visualizer, "set_audio_analyzer"):
+                        self.current_visualizer.set_audio_analyzer(self.audio_analyzer)
                     
                     # Update controls cache
                     self._update_controls_cache()
@@ -344,6 +352,8 @@ class Deck:
         if self.current_visualizer:
             logging.debug(f"🧹 Deck {self.deck_id}: Cleaning up visualizer: {self.current_visualizer_name}")
             try:
+                if hasattr(self.current_visualizer, 'set_audio_analyzer'):
+                    self.current_visualizer.set_audio_analyzer(None)
                 if hasattr(self.current_visualizer, 'cleanup'):
                     self.current_visualizer.cleanup()
             except Exception as e:

--- a/visuals/presets/cosmic_flow.py
+++ b/visuals/presets/cosmic_flow.py
@@ -28,7 +28,8 @@ class CosmicFlowVisualizer(BaseVisualizer):
         self.initialized = False
 
     def get_controls(self):
-        return {
+        controls = super().get_controls()
+        controls.update({
             "Speed": {
                 "type": "slider",
                 "min": 0,
@@ -58,9 +59,12 @@ class CosmicFlowVisualizer(BaseVisualizer):
                 "options": ["White Stars", "Rainbow", "Blue Shift", "Fire Nebula", "Crystal Galaxy"],
                 "value": self.color_mode,
             }
-        }
+        })
+        return controls
 
     def update_control(self, name, value):
+        if super().update_control(name, value):
+            return
         if name == "Speed":
             self.speed = float(value) / 100.0
         elif name == "Star Count":
@@ -324,9 +328,15 @@ class CosmicFlowVisualizer(BaseVisualizer):
             glUseProgram(self.shader_program)
             
             # Set uniforms
+            # Fetch audio bands
+            bass, mid, treble = self.get_audio_bands()
+
             glUniform1f(glGetUniformLocation(self.shader_program, "time"), current_time)
-            glUniform1f(glGetUniformLocation(self.shader_program, "speed"), self.speed)
-            glUniform1f(glGetUniformLocation(self.shader_program, "star_size"), self.star_size)
+            glUniform1f(glGetUniformLocation(self.shader_program, "speed"), self.speed * (0.5 + bass))
+            glUniform1f(
+                glGetUniformLocation(self.shader_program, "star_size"),
+                self.star_size * (0.5 + treble),
+            )
             
             # Draw stars
             glBindVertexArray(self.vao)

--- a/visuals/presets/fluid_particles.py
+++ b/visuals/presets/fluid_particles.py
@@ -30,7 +30,8 @@ class FluidParticlesVisualizer(BaseVisualizer):
         self.attractors = []
 
     def get_controls(self):
-        return {
+        controls = super().get_controls()
+        controls.update({
             "Particle Count": {
                 "type": "slider",
                 "min": 500,
@@ -72,9 +73,12 @@ class FluidParticlesVisualizer(BaseVisualizer):
                 "options": ["Plasma Storm", "Aurora Dreams", "Deep Void", "Fire Galaxy", "Crystal Nebula", "Neon Pulse", "Rainbow Flow"],
                 "value": self.color_mode,
             }
-        }
+        })
+        return controls
 
     def update_control(self, name, value):
+        if super().update_control(name, value):
+            return
         if name == "Particle Count":
             old_count = self.num_particles
             self.num_particles = int(value)

--- a/visuals/presets/geometric_particles.py
+++ b/visuals/presets/geometric_particles.py
@@ -24,7 +24,8 @@ class GeometricParticlesVisualizer(BaseVisualizer):
         self.shape_type = 0
 
     def get_controls(self):
-        return {
+        controls = super().get_controls()
+        controls.update({
             "Particle Count": {
                 "type": "slider", "min": 1000, "max": 50000, "value": self.num_particles
             },
@@ -34,9 +35,12 @@ class GeometricParticlesVisualizer(BaseVisualizer):
             "Shape Type": {
                 "type": "dropdown", "options": ["Pulsating Sphere", "Animated Torus", "Abstract Cloud"], "value": self.shape_type
             }
-        }
+        })
+        return controls
 
     def update_control(self, name, value):
+        if super().update_control(name, value):
+            return
         if name == "Particle Count":
             self.num_particles = int(value)
             self.setup_particles() # Re-initialize particles
@@ -167,13 +171,15 @@ class GeometricParticlesVisualizer(BaseVisualizer):
 
         self.update_particles()
 
+        bass, mid, treble = self.get_audio_bands()
+
         view = self.lookAt(np.array([0.0, 0.0, 10.0]), np.array([0.0, 0.0, 0.0]), np.array([0.0, 1.0, 0.0]))
-        model = self.rotate(self.time * 15, 0, 1, 0) @ self.rotate(self.time * 10, 1, 0, 0)
+        model = self.rotate(self.time * 15 * (0.5 + bass), 0, 1, 0) @ self.rotate(self.time * 10 * (0.5 + treble), 1, 0, 0)
 
         glUniformMatrix4fv(glGetUniformLocation(self.shader_program, "view"), 1, GL_FALSE, view)
         glUniformMatrix4fv(glGetUniformLocation(self.shader_program, "model"), 1, GL_FALSE, model)
 
-        glPointSize(self.point_size)
+        glPointSize(self.point_size * (0.5 + mid))
 
         glBindVertexArray(self.VAO)
         glDrawArrays(GL_POINTS, 0, self.num_particles)


### PR DESCRIPTION
## Summary
- add global `Audio Reactive` control in `BaseVisualizer`
- hook audio-driven modulation into several presets with analyzer band helpers
- allow disabling reactivity via visual settings per preset

## Testing
- `python -m py_compile visuals/base_visualizer.py visuals/presets/abstract_lines.py visuals/presets/abstract_shapes.py visuals/presets/cosmic_flow.py visuals/presets/evolutive_particles.py visuals/presets/infinite_neural.py visuals/presets/building_madness.py visuals/presets/fluid_particles.py visuals/presets/geometric_particles.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68a23109f420833398bbad641669638c