### PR TITLE
Refactor visual settings layout to two-column rows

### DIFF
--- a/visuals/base_visualizer.py
+++ b/visuals/base_visualizer.py
@@ -56,18 +56,21 @@ class BaseVisualizer:
             "Audio Reactive": {
                 "type": "checkbox",
                 "value": self.audio_reactive,
+                "description": "Enable or disable audio-driven effects",
             },
             "Audio Sensitivity": {
                 "type": "slider",
                 "min": 0,
                 "max": 100,
                 "value": int(self.audio_sensitivity),
+                "description": "Adjust how strongly the visual reacts to audio",
             },
             "Smoothness": {
                 "type": "slider",
                 "min": 0,
                 "max": 100,
                 "value": int(self.audio_smoothness),
+                "description": "Higher values smooth out rapid audio changes",
             },
         }
 


### PR DESCRIPTION
## Summary
- Replace visual settings grid with vertically stacked rows for each visual
- Group audio controls and visual properties in right column with tooltips
- Add descriptions to base audio controls and enforce numeric MIDI note input

## Testing
- `pytest -q` *(fails: No module named 'PyQt6', No module named 'moderngl')*


------
https://chatgpt.com/codex/tasks/task_e_68a246fcb6688333a99a5174a0560019