### PR TITLE
Integrate Taichi visuals with OpenGL rendering

### DIFF
--- a/visuals/base.py
+++ b/visuals/base.py
@@ -1,16 +1,71 @@
-from __future__ import annotations
-from typing import Tuple
-from render.taichi_renderer import TaichiRenderer
+"""Common Taichi visual base class integrated with the OpenGL pipeline."""
 
-class TaichiVisual:
-    """Base class for visuals rendered with TaichiRenderer."""
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+from OpenGL.GL import (
+    GL_FLOAT,
+    GL_LUMINANCE,
+    GL_UNPACK_ALIGNMENT,
+    glDrawPixels,
+    glPixelStorei,
+)
+
+from render.taichi_renderer import TaichiRenderer
+from .base_visualizer import BaseVisualizer
+
+
+class TaichiVisual(BaseVisualizer):
+    """Base class for Taichi-powered visuals.
+
+    The original project used OpenGL based visualizers.  For the Taichi
+    presets to be usable inside the existing application the base class now
+    subclasses :class:`BaseVisualizer` and implements the ``initializeGL``,
+    ``resizeGL`` and ``paintGL`` methods expected by the UI.  Each render
+    call produces a grayscale image which is uploaded using ``glDrawPixels``.
+    """
+
     def __init__(self, resolution: Tuple[int, int] = (640, 480)):
+        super().__init__()
+        self.resolution = resolution
         self.renderer = TaichiRenderer(resolution)
         self.setup()
 
-    def setup(self) -> None:
-        """Hook to register passes on the renderer."""
-        pass
+    # ------------------------------------------------------------------
+    # Life-cycle hooks --------------------------------------------------
+    # ------------------------------------------------------------------
+    def setup(self) -> None:  # pragma: no cover - meant to be overridden
+        """Hook for subclasses to register Taichi render passes."""
+        return None
 
-    def render(self):
+    def initializeGL(self, backend=None):  # pragma: no cover - no GL state
+        """No OpenGL resources are required for Taichi visuals."""
+        return None
+
+    def resizeGL(self, width: int, height: int, backend=None):
+        """Recreate the Taichi renderer on resize."""
+        if (width, height) != self.resolution:
+            self.resolution = (width, height)
+            # Recreate renderer to resize canvas
+            self.renderer = TaichiRenderer(self.resolution)
+            self.setup()
+
+    def paintGL(self, time: float = 0.0, size: Tuple[int, int] | None = None, backend=None):
+        """Render the Taichi frame and blit it using OpenGL."""
+        img = self.render()
+        # ``TaichiRenderer`` returns an array shaped (width, height)
+        h = img.shape[1]
+        w = img.shape[0]
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
+        # Transpose so rows correspond to the Y axis for OpenGL
+        glDrawPixels(w, h, GL_LUMINANCE, GL_FLOAT, np.ascontiguousarray(img.T))
+
+    # ------------------------------------------------------------------
+    # Rendering ---------------------------------------------------------
+    # ------------------------------------------------------------------
+    def render(self) -> np.ndarray:
+        """Execute registered passes and return the canvas as ``numpy``."""
         return self.renderer.render()
+


### PR DESCRIPTION
## Summary
- Bridge Taichi visual presets into existing OpenGL pipeline
- Handle resizing and frame blitting via glDrawPixels for TaichiRenderer output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68a3945023e08333992b71bf874622f6