### PR TITLE
Fix AbstractLines visual offset

### DIFF
--- a/visuals/presets/abstract_lines.py
+++ b/visuals/presets/abstract_lines.py
@@ -24,6 +24,7 @@ class AbstractLinesVisualizer(TaichiVisual):
         self.renderer.add_pass("lines", lambda img: _lines(img, self.offset, self.spacing))
 
     def render(self):
+        img = super().render()
         if self.spacing > 0:
             self.offset = (self.offset + 1) % self.spacing
-        return super().render()
+        return img


### PR DESCRIPTION
## Summary
- ensure AbstractLines visual starts rendering from offset 0 and updates offset after each frame

## Testing
- `pytest test_abstract_lines_visual.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a42b55828483338890fe60176a0b91