### PR TITLE
Fix control panel initialization after splash

### DIFF
--- a/ui/main_application.py
+++ b/ui/main_application.py
@@ -363,7 +363,8 @@ class MainApplication:
                 visualizer_manager=visualizer_manager,
                 mixer_window=self.mixer_window,
                 settings_manager=SettingsManager(),
-                midi_engine=midi_engine
+                midi_engine=midi_engine,
+                audio_analyzer=audio_analyzer
             )
             
             # Position windows nicely


### PR DESCRIPTION
## Summary
- pass `audio_analyzer` to `ControlPanelWindow` when building main windows

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4847586dc833392418d03a8d46358