### PR TITLE
fix: corregir sintaxis CSS

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,7 +34,7 @@ body {
 .layer-grid-container {
   grid-area: layer-grid;
   overflow: hidden;
-  background: #0A0A* {
+  background: #0A0A0A;
   margin: 0;
   padding: 0;
   box-sizing: border-box;

--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -1,6 +1,8 @@
 .layer-grid {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  backgroun/* LayerGrid.css */
+  background: #0A0A0A; /* LayerGrid.css */
+}
+
 .layer-grid {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background: #0A0A0A;


### PR DESCRIPTION
## Summary
- corrige fondo de `.layer-grid-container` y cierra reglas
- repara encabezado de `LayerGrid.css` con propiedad `background` válida

## Testing
- `npx vite build`
- `npm run build --silent` *(falla: Error failed to get cargo metadata: No such file or directory (os error 2))*

------
https://chatgpt.com/codex/tasks/task_e_68a4f2d319e083338a3a786165d27456