### PR TITLE
fix: skip resolving optional tauri import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,10 @@ const App: React.FC = () => {
     const setupAudioListener = async () => {
       try {
         // Intenta importar dinámicamente la API de eventos de Tauri.
-        const { listen } = await import('@tauri-apps/api/event');
+        // El comentario `@vite-ignore` evita que Vite intente resolver el módulo
+        // durante la compilación, permitiendo que la importación falle en tiempo
+        // de ejecución si el paquete no está disponible (por ejemplo, en Electron).
+        const { listen } = await import(/* @vite-ignore */ '@tauri-apps/api/event');
 
         await listen('audio_data', (event) => {
           const data = event.payload as AudioData;


### PR DESCRIPTION
## Summary
- avoid Vite resolution errors by ignoring optional `@tauri-apps/api` event import

## Testing
- `npm run electron` *(fails: `/workspace/AudioVisualizer/node_modules/electron/dist/electron: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68a559b7c9448333a964b86274f9991a