### PR TITLE
fix: dynamic import tauri api for electron

### DIFF
--- a/App.ts
+++ b/App.ts
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { listen } from '@tauri-apps/api/event';
 import { PresetLoader, LoadedPreset, AudioData } from './PresetLoader';
 
 export class AudioVisualizerApp {
@@ -76,13 +75,21 @@ export class AudioVisualizerApp {
 
   private async setupAudioListener(): Promise<void> {
     try {
+      // Importar dinámicamente la API de eventos de Tauri. El comentario
+      // `@vite-ignore` evita que Vite intente resolver este módulo en
+      // entornos donde no está disponible (por ejemplo, Electron puro).
+      const { listen } = await import(
+        /* @vite-ignore */ '@tauri-apps/api/event'
+      );
+
       await listen('audio_data', (event) => {
         const audioData = event.payload as AudioData;
         this.presetLoader.updateAudioData(audioData);
       });
       console.log('🎵 Audio listener setup complete');
     } catch (error) {
-      console.error('Failed to setup audio listener:', error);
+      // Si la API no está disponible simplemente registra un aviso.
+      console.warn('Failed to setup audio listener:', error);
     }
   }
 

--- a/src/components/PreviewControls.tsx
+++ b/src/components/PreviewControls.tsx
@@ -1,12 +1,17 @@
 import React, { useState } from 'react';
-import { invoke } from '@tauri-apps/api';
 
 export default function PreviewControls() {
   const [sensitivity, setSensitivity] = useState(0.5);
   const [smoothness, setSmoothness] = useState(0.5);
 
-  const fullscreenAll = () => {
-    invoke('fullscreen_all').catch(() => {});
+  const fullscreenAll = async () => {
+    try {
+      // Importar dinámicamente para evitar errores cuando la API de Tauri no esté disponible.
+      const { invoke } = await import(/* @vite-ignore */ '@tauri-apps/api');
+      await invoke('fullscreen_all');
+    } catch (e) {
+      console.warn('Fullscreen not available:', e);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- use dynamic import for tauri event API
- load tauri invoke only when needed

## Testing
- `npm run electron` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a561c73a0c8333aaf52f174695bd87