### PR TITLE
Fix layer-specific opacity and add text-glitch preset

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,15 +157,8 @@ const App: React.FC = () => {
     if (!engineRef.current) return;
 
     console.log(`🎨 Activating preset ${presetId} on layer ${layerId}`);
-    
-    // Desactivar preset anterior de esta capa si existe
-    const previousPreset = activeLayers[layerId];
-    if (previousPreset) {
-      engineRef.current.deactivateCurrentPreset();
-    }
 
-    // Activar nuevo preset
-    const success = engineRef.current.activatePreset(presetId);
+    const success = engineRef.current.activatePreset(layerId, presetId);
     if (success) {
       setActiveLayers(prev => ({ ...prev, [layerId]: presetId }));
       setStatus(`Layer ${layerId}: ${availablePresets.find(p => p.id === presetId)?.config.name}`);
@@ -176,7 +169,7 @@ const App: React.FC = () => {
     if (!engineRef.current) return;
 
     console.log(`🗑️ Clearing layer ${layerId}`);
-    engineRef.current.deactivateCurrentPreset();
+    engineRef.current.deactivateLayerPreset(layerId);
     
     setActiveLayers(prev => {
       const newLayers = { ...prev };
@@ -194,11 +187,11 @@ const App: React.FC = () => {
     
     // Aplicar cambios de opacidad
     if (config.opacity !== undefined) {
-      engineRef.current.setOpacity(config.opacity / 100);
+      engineRef.current.setLayerOpacity(layerId, config.opacity / 100);
     }
-    
+
     // Aplicar otros cambios de configuración
-    engineRef.current.updatePresetConfig(config);
+    engineRef.current.updateLayerConfig(layerId, config);
   };
 
   const getCurrentPresetName = (): string => {

--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -125,12 +125,12 @@
   background: #555;
 }
 
-/* Preset Cell - 88px x 88px para caber en 100px con padding */
+/* Preset Cell - 100x100 */
 .preset-cell {
   position: relative;
-  width: 88px;
-  height: 88px;
-  min-width: 88px; /* Para evitar que se comprima en flex */
+  width: 100px;
+  height: 100px;
+  min-width: 100px;
   background: linear-gradient(135deg, #1E1E1E, #181818);
   border: 1px solid #333;
   border-radius: 6px;
@@ -139,8 +139,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  padding: 6px;
+  justify-content: flex-start;
   overflow: hidden;
   user-select: none;
 }
@@ -164,57 +163,44 @@
 }
 
 .preset-thumbnail {
-  font-size: 20px;
-  margin-bottom: 3px;
+  width: 100%;
+  height: 85px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
 }
 
 .preset-info {
-  text-align: center;
-  flex: 1;
+  width: 100%;
+  height: 15px;
   display: flex;
   flex-direction: column;
+  align-items: center;
   justify-content: center;
-  gap: 1px;
+  text-align: center;
 }
 
 .preset-name {
+  height: 10px;
   font-size: 9px;
   font-weight: 600;
   color: #FFF;
-  line-height: 1.1;
-  max-height: 18px;
+  line-height: 10px;
   overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
 }
 
 .preset-category {
+  height: 5px;
   font-size: 7px;
   color: #888;
   font-weight: 400;
   text-transform: uppercase;
   letter-spacing: 0.3px;
+  line-height: 5px;
 }
 
-.preset-tags {
-  display: flex;
-  gap: 1px;
-  margin-top: 2px;
-  justify-content: center;
-}
-
-.tag {
-  font-size: 6px;
-  padding: 1px 3px;
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 2px;
-  color: #CCC;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.2px;
-}
 
 .active-indicator {
   position: absolute;

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -79,7 +79,8 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
       'abstract-shapes': '🔷',
       'evolutive-particles': '✨',
       'plasma-ray': '⚡',
-      'shot-text': '📝'
+      'shot-text': '📝',
+      'text-glitch': '🔤'
     };
     return thumbnails[preset.id] || '🎨';
   };
@@ -151,11 +152,6 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
                   <div className="preset-info">
                     <div className="preset-name">{preset.config.name}</div>
                     <div className="preset-category">{preset.config.category}</div>
-                  </div>
-                  <div className="preset-tags">
-                    {preset.config.tags.slice(0, 2).map(tag => (
-                      <span key={tag} className="tag">{tag}</span>
-                    ))}
                   </div>
                   
                   {isActive && (

--- a/src/core/PresetLoader.ts
+++ b/src/core/PresetLoader.ts
@@ -92,7 +92,8 @@ export class PresetLoader {
     'neural_network',
     'abstract-lines',
     'evolutive-particles',
-    'plasma-ray'
+    'plasma-ray',
+    'text-glitch'
   ];
 
   constructor(


### PR DESCRIPTION
## Summary
- add per-layer preset management in engine so opacity and config changes only affect the targeted layer
- load new `text-glitch` preset and display its thumbnail
- redesign preset grid cells with centered icons and bottom-aligned name and category

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5905cad9c8333ae7159d0c0e2b2dd