### PR TITLE
feat: enhance grid and preset controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,23 +16,10 @@ body {
   width: 100vw;
   height: 100vh;
   display: grid;
-  grid-template-areas: 
-    "layer-grid"
-    "canvas"
-    "status";
-  grid-template-rows: 360px 1fr 80px; /* 360px fijos para 3 capas de 120px */
-}
-
-.main-canvas {
-  grid-area: canvas;
-  width: 100%;
-  height: 100%;
-  background: #000;
-  border-top: 1px solid #333;
+  grid-template-rows: 300px 1fr;
 }
 
 .layer-grid-container {
-  grid-area: layer-grid;
   overflow: hidden;
   background: #0A0A0A;
   margin: 0;
@@ -40,41 +27,28 @@ body {
   box-sizing: border-box;
 }
 
-body {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background: #000;
-  color: #fff;
-  overflow: hidden;
-}
-
-.app {
-  position: relative;
-  width: 100vw;
-  height: 100vh;
+.bottom-section {
+  display: flex;
+  width: 100%;
+  height: 100%;
 }
 
 .main-canvas {
-  position: absolute;
-  top: 0;
-  left: 0;
+  flex: 1;
+  background: #000;
   width: 100%;
   height: 100%;
-  z-index: 1;
-  background: #000;
+  border-top: 1px solid #333;
 }
 
 .controls-panel {
-  position: absolute;
-  top: 20px;
-  right: 20px;
   width: 320px;
-  max-height: calc(100vh - 120px);
+  max-height: 100%;
   background: rgba(0, 0, 0, 0.85);
   backdrop-filter: blur(15px);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 12px;
   padding: 20px;
-  z-index: 10;
   overflow-y: auto;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { AudioVisualizerEngine } from './core/AudioVisualizerEngine';
 import { LayerGrid } from './components/LayerGrid';
 import { StatusBar } from './components/StatusBar';
+import { PresetControls } from './components/PresetControls';
 import { LoadedPreset, AudioData } from './core/PresetLoader';
 import './App.css';
 import './components/LayerGrid.css';
@@ -16,6 +17,8 @@ const App: React.FC = () => {
   const [fps, setFps] = useState(60);
   const [status, setStatus] = useState('Inicializando...');
   const [activeLayers, setActiveLayers] = useState<Record<string, string>>({});
+  const [selectedPreset, setSelectedPreset] = useState<LoadedPreset | null>(null);
+  const [selectedLayer, setSelectedLayer] = useState<string | null>(null);
 
   // Inicializar el engine
   useEffect(() => {
@@ -162,6 +165,8 @@ const App: React.FC = () => {
     if (success) {
       setActiveLayers(prev => ({ ...prev, [layerId]: presetId }));
       setStatus(`Layer ${layerId}: ${availablePresets.find(p => p.id === presetId)?.config.name}`);
+      setSelectedPreset(availablePresets.find(p => p.id === presetId) || null);
+      setSelectedLayer(layerId);
     }
   };
 
@@ -194,6 +199,11 @@ const App: React.FC = () => {
     engineRef.current.updateLayerConfig(layerId, config);
   };
 
+  const handlePresetConfigUpdate = (config: any) => {
+    if (!engineRef.current || !selectedLayer) return;
+    engineRef.current.updateLayerConfig(selectedLayer, config);
+  };
+
   const getCurrentPresetName = (): string => {
     const activeLayerIds = Object.keys(activeLayers);
     if (activeLayerIds.length === 0) return 'Ninguno';
@@ -209,13 +219,7 @@ const App: React.FC = () => {
 
   return (
     <div className="app">
-      {/* Canvas principal para renderizado */}
-      <canvas 
-        ref={canvasRef}
-        className="main-canvas"
-      />
-      
-      {/* Grid de capas estilo Resolume */}
+      {/* Grid de capas */}
       <div className="layer-grid-container">
         <LayerGrid
           presets={availablePresets}
@@ -224,7 +228,17 @@ const App: React.FC = () => {
           onLayerConfigChange={handleLayerConfigChange}
         />
       </div>
-      
+
+      {/* Sección inferior con visuales y controles */}
+      <div className="bottom-section">
+        <canvas ref={canvasRef} className="main-canvas" />
+        {selectedPreset && (
+          <div className="controls-panel">
+            <PresetControls preset={selectedPreset} onConfigUpdate={handlePresetConfigUpdate} />
+          </div>
+        )}
+      </div>
+
       {/* Barra de estado */}
       <StatusBar
         status={status}

--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -16,8 +16,9 @@
 .layer-section {
   height: 100px; /* Altura fija: controles + grid */
   background: #111111;
-  border-bottom: 1px solid #222;
+  border-bottom: 1px solid #FFFFFF;
   display: flex;
+  gap: 1px;
 }
 
 .layer-sidebar {
@@ -31,6 +32,7 @@
   justify-content: center;
   gap: 6px;
   flex-shrink: 0;
+  border-radius: 0;
 }
 
 .layer-letter {
@@ -98,8 +100,8 @@
 .preset-grid {
   height: 100px;
   display: flex;
-  gap: 6px;
-  padding: 6px 12px;
+  gap: 1px;
+  padding: 1px;
   background: #0F0F0F;
   overflow-x: auto;
   overflow-y: hidden;
@@ -133,7 +135,7 @@
   min-width: 100px;
   background: linear-gradient(135deg, #1E1E1E, #181818);
   border: 1px solid #333;
-  border-radius: 6px;
+  border-radius: 0;
   cursor: pointer;
   transition: all 0.2s ease;
   display: flex;
@@ -190,8 +192,7 @@
   line-height: 10px;
   overflow: hidden;
 }
-
-.preset-category {
+.preset-details {
   height: 5px;
   font-size: 7px;
   color: #888;
@@ -199,6 +200,13 @@
   text-transform: uppercase;
   letter-spacing: 0.3px;
   line-height: 5px;
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+}
+
+.preset-note {
+  color: #aaa;
 }
 
 

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -151,7 +151,12 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
                   </div>
                   <div className="preset-info">
                     <div className="preset-name">{preset.config.name}</div>
-                    <div className="preset-category">{preset.config.category}</div>
+                    <div className="preset-details">
+                      <span className="preset-category">{preset.config.category}</span>
+                      {preset.config.note !== undefined && (
+                        <span className="preset-note">note:{preset.config.note}</span>
+                      )}
+                    </div>
                   </div>
                   
                   {isActive && (

--- a/src/components/PresetControls.tsx
+++ b/src/components/PresetControls.tsx
@@ -12,9 +12,9 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
 }) => {
   const handleControlChange = (controlName: string, value: any, type: string) => {
     let processedValue = value;
-    
+
     // Procesar valor según el tipo
-    if (type === 'slider') {
+    if (type === 'slider' || type === 'number') {
       processedValue = parseFloat(value);
     } else if (type === 'checkbox') {
       processedValue = value;
@@ -51,6 +51,19 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
             defaultValue={control.default || 0}
             onChange={(e) => handleControlChange(control.name, e.target.value, 'slider')}
             className="control-slider"
+          />
+        );
+
+      case 'number':
+        return (
+          <input
+            type="number"
+            min={control.min}
+            max={control.max}
+            step={control.step || 1}
+            defaultValue={control.default || 0}
+            onChange={(e) => handleControlChange(control.name, e.target.value, 'number')}
+            className="control-text"
           />
         );
         
@@ -101,6 +114,69 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
     }
   };
 
+  const baseControls = [
+    {
+      name: 'width',
+      type: 'number',
+      label: 'Width',
+      min: 0,
+      max: 4096,
+      default: preset.config.defaultConfig.width || 1920
+    },
+    {
+      name: 'height',
+      type: 'number',
+      label: 'Height',
+      min: 0,
+      max: 4096,
+      default: preset.config.defaultConfig.height || 1080
+    },
+    {
+      name: 'zoom',
+      type: 'slider',
+      label: 'Zoom',
+      min: 0.1,
+      max: 5,
+      step: 0.1,
+      default: preset.config.defaultConfig.zoom || 1
+    },
+    {
+      name: 'audioSensitivity',
+      type: 'slider',
+      label: 'Audio Sensitivity',
+      min: 0,
+      max: 2,
+      step: 0.01,
+      default: preset.config.defaultConfig.audioSensitivity || 1
+    },
+    {
+      name: 'audioSmoothness',
+      type: 'slider',
+      label: 'Audio Smoothness',
+      min: 0,
+      max: 1,
+      step: 0.01,
+      default: preset.config.defaultConfig.audioSmoothness || 0.5
+    },
+    {
+      name: 'audioReactivity',
+      type: 'slider',
+      label: 'Audio Reactivity',
+      min: 0,
+      max: 2,
+      step: 0.01,
+      default: preset.config.defaultConfig.audioReactivity || 1
+    },
+    {
+      name: 'paletteColor',
+      type: 'color',
+      label: 'Palette Color',
+      default: preset.config.defaultConfig.paletteColor || '#ffffff'
+    }
+  ];
+
+  const combinedControls = [...baseControls, ...preset.config.controls];
+
   return (
     <div className="preset-controls-container">
       <div className="preset-info">
@@ -125,7 +201,7 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
 
       <div className="controls-list">
         <h4>Controles</h4>
-        {preset.config.controls.map((control) => (
+        {combinedControls.map((control) => (
           <div key={control.name} className="control-group">
             <label className="control-label">
               {control.label}:

--- a/src/core/PresetLoader.ts
+++ b/src/core/PresetLoader.ts
@@ -8,6 +8,7 @@ export interface PresetConfig {
   category: string;
   tags: string[];
   thumbnail?: string;
+  note?: number;
   defaultConfig: any;
   controls: Array<{
     name: string;

--- a/src/presets/abstract-lines/config.json
+++ b/src/presets/abstract-lines/config.json
@@ -6,7 +6,15 @@
   "category": "abstract",
   "tags": ["abstract", "lines", "organic", "fluid", "minimal", "geometric"],
   "thumbnail": "abstract_lines_thumb.png",
+  "note": 51,
   "defaultConfig": {
+    "width": 1920,
+    "height": 1080,
+    "zoom": 1.0,
+    "audioSensitivity": 1.0,
+    "audioSmoothness": 0.5,
+    "audioReactivity": 1.0,
+    "paletteColor": "#ffffff",
     "opacity": 1.0,
     "fadeMs": 300,
     "lineCount": {

--- a/src/presets/evolutive-particles/config.json
+++ b/src/presets/evolutive-particles/config.json
@@ -6,7 +6,15 @@
   "category": "particles",
   "tags": ["particles", "evolution", "organic", "complex", "adaptive", "swarm"],
   "thumbnail": "evolutive_particles_thumb.png",
+  "note": 52,
   "defaultConfig": {
+    "width": 1920,
+    "height": 1080,
+    "zoom": 1.0,
+    "audioSensitivity": 1.0,
+    "audioSmoothness": 0.5,
+    "audioReactivity": 1.0,
+    "paletteColor": "#ffffff",
     "opacity": 1.0,
     "fadeMs": 250,
     "particleCount": {

--- a/src/presets/neural_network/config.json
+++ b/src/presets/neural_network/config.json
@@ -6,7 +6,15 @@
   "category": "abstract",
   "tags": ["neural", "network", "infinite", "starfield"],
   "thumbnail": "neural_network_thumb.png",
+  "note": 50,
   "defaultConfig": {
+    "width": 1920,
+    "height": 1080,
+    "zoom": 1.0,
+    "audioSensitivity": 1.0,
+    "audioSmoothness": 0.5,
+    "audioReactivity": 1.0,
+    "paletteColor": "#ffffff",
     "speed": 5,
     "nodeSize": 0.05,
     "colors": {

--- a/src/presets/plasma-ray/config.json
+++ b/src/presets/plasma-ray/config.json
@@ -6,7 +6,15 @@
   "category": "energy",
   "tags": ["plasma", "energy", "electric", "lightning", "rays", "power"],
   "thumbnail": "plasma_ray_thumb.png",
+  "note": 54,
   "defaultConfig": {
+    "width": 1920,
+    "height": 1080,
+    "zoom": 1.0,
+    "audioSensitivity": 1.0,
+    "audioSmoothness": 0.5,
+    "audioReactivity": 1.0,
+    "paletteColor": "#ffffff",
     "opacity": 1.0,
     "fadeMs": 150,
     "raySystem": {

--- a/src/presets/shot-text/config.json
+++ b/src/presets/shot-text/config.json
@@ -6,7 +6,15 @@
   "category": "text",
   "tags": ["text", "intro", "robotica", "cinematic", "glow", "animation"],
   "thumbnail": "robotica_intro_thumb.png",
+  "note": 53,
   "defaultConfig": {
+    "width": 1920,
+    "height": 1080,
+    "zoom": 1.0,
+    "audioSensitivity": 1.0,
+    "audioSmoothness": 0.5,
+    "audioReactivity": 1.0,
+    "paletteColor": "#ffffff",
     "opacity": 1.0,
     "fadeMs": 200,
     "text": {

--- a/src/presets/text-glitch/config.json
+++ b/src/presets/text-glitch/config.json
@@ -6,7 +6,15 @@
   "category": "text",
   "tags": ["text", "glitch", "animated", "cyberpunk", "digital"],
   "thumbnail": "text_glitch_thumb.png",
+  "note": 55,
   "defaultConfig": {
+    "width": 1920,
+    "height": 1080,
+    "zoom": 1.0,
+    "audioSensitivity": 1.0,
+    "audioSmoothness": 0.5,
+    "audioReactivity": 1.0,
+    "paletteColor": "#ffffff",
     "opacity": 1.0,
     "fadeMs": 500,
     "text": {


### PR DESCRIPTION
## Summary
- show preset name, category, and MIDI note under each grid thumbnail
- square grid cells with 1px spacing and white layer separators
- add bottom controls panel with base controls (size, zoom, audio params, palette)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find web assets)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68a5cc42765c8333872cb5a74a26a167