### PR TITLE
feat: add top bar and global settings modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,7 +16,7 @@ body {
   width: 100vw;
   height: 100vh;
   display: grid;
-  grid-template-rows: 300px 1fr;
+  grid-template-rows: 40px 300px 1fr;
 }
 
 .layer-grid-container {
@@ -453,4 +453,96 @@ body {
 
 .controls-panel::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.5);
+}
+
+/* Top Bar */
+.top-bar {
+  grid-row: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(0, 0, 0, 0.85);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 5px 10px;
+  font-size: 12px;
+  z-index: 20;
+}
+
+.midi-led {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #555;
+}
+
+.midi-led.active {
+  background: #0f0;
+}
+
+.separator {
+  width: 1px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.audio-section {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.audio-gain-slider {
+  width: 80px;
+}
+
+.vu-meter {
+  width: 60px;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.vu-fill {
+  height: 100%;
+  background: #4caf50;
+}
+
+.actions-section button {
+  margin-right: 5px;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal-content {
+  background: #222;
+  padding: 20px;
+  border-radius: 8px;
+  min-width: 300px;
+  color: #fff;
+}
+
+.modal-section {
+  margin-bottom: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.monitor-option {
+  display: flex;
+  align-items: center;
+  gap: 5px;
 }

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+
+interface DeviceOption {
+  id: string;
+  label: string;
+}
+
+interface GlobalSettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  audioDevices: DeviceOption[];
+  midiDevices: DeviceOption[];
+  selectedAudioId: string | null;
+  selectedMidiId: string | null;
+  onSelectAudio: (id: string) => void;
+  onSelectMidi: (id: string) => void;
+  audioGain: number;
+  onAudioGainChange: (value: number) => void;
+  monitors: DeviceOption[];
+  selectedMonitors: string[];
+  onToggleMonitor: (id: string) => void;
+}
+
+export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
+  isOpen,
+  onClose,
+  audioDevices,
+  midiDevices,
+  selectedAudioId,
+  selectedMidiId,
+  onSelectAudio,
+  onSelectMidi,
+  audioGain,
+  onAudioGainChange,
+  monitors,
+  selectedMonitors,
+  onToggleMonitor
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content">
+        <h2>Global Settings</h2>
+        <div className="modal-section">
+          <h3>Audio</h3>
+          <label>
+            Dispositivo de entrada:
+            <select
+              value={selectedAudioId || ''}
+              onChange={(e) => onSelectAudio(e.target.value)}
+            >
+              <option value="">Default</option>
+              {audioDevices.map(dev => (
+                <option key={dev.id} value={dev.id}>{dev.label}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Ganancia de entrada:
+            <input
+              type="range"
+              min={0}
+              max={2}
+              step={0.01}
+              value={audioGain}
+              onChange={(e) => onAudioGainChange(parseFloat(e.target.value))}
+            />
+          </label>
+        </div>
+
+        <div className="modal-section">
+          <h3>MIDI</h3>
+          <label>
+            Dispositivo de entrada:
+            <select
+              value={selectedMidiId || ''}
+              onChange={(e) => onSelectMidi(e.target.value)}
+            >
+              <option value="">Default</option>
+              {midiDevices.map(dev => (
+                <option key={dev.id} value={dev.id}>{dev.label}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="modal-section">
+          <h3>Full Screen Monitors</h3>
+          {monitors.map(mon => (
+            <label key={mon.id} className="monitor-option">
+              <input
+                type="checkbox"
+                checked={selectedMonitors.includes(mon.id)}
+                onChange={() => onToggleMonitor(mon.id)}
+              />
+              {mon.label}
+            </label>
+          ))}
+        </div>
+
+        <button onClick={onClose}>Cerrar</button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+interface TopBarProps {
+  midiActive: boolean;
+  midiDeviceName: string | null;
+  midiDeviceCount: number;
+  bpm: number | null;
+  audioDeviceName: string | null;
+  audioDeviceCount: number;
+  audioGain: number;
+  onAudioGainChange: (value: number) => void;
+  audioLevel: number;
+  onFullScreen: () => void;
+  onClearAll: () => void;
+  onOpenSettings: () => void;
+}
+
+export const TopBar: React.FC<TopBarProps> = ({
+  midiActive,
+  midiDeviceName,
+  midiDeviceCount,
+  bpm,
+  audioDeviceName,
+  audioDeviceCount,
+  audioGain,
+  onAudioGainChange,
+  audioLevel,
+  onFullScreen,
+  onClearAll,
+  onOpenSettings
+}) => {
+  return (
+    <div className="top-bar">
+      <div className="midi-section">
+        <div className={`midi-led ${midiActive ? 'active' : ''}`}></div>
+        <span className="midi-device">
+          {midiDeviceName || `${midiDeviceCount} MIDI dispositivos`}
+        </span>
+      </div>
+
+      <div className="separator" />
+
+      <div className="bpm-section">
+        <span>BPM: {bpm ? bpm.toFixed(1) : '--'}</span>
+      </div>
+
+      <div className="separator" />
+
+      <div className="audio-section">
+        <span className="audio-device">
+          {audioDeviceName || `${audioDeviceCount} audio dispositivos`}
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={2}
+          step={0.01}
+          value={audioGain}
+          onChange={(e) => onAudioGainChange(parseFloat(e.target.value))}
+          className="audio-gain-slider"
+        />
+        <div className="vu-meter">
+          <div
+            className="vu-fill"
+            style={{ width: `${Math.min(audioLevel * 100, 100)}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="separator" />
+
+      <div className="actions-section">
+        <button onClick={onFullScreen} alt="Go Full Screen mode!!">Full Screen</button>
+        <button onClick={onClearAll}>Clear All</button>
+        <button onClick={onOpenSettings}>Settings</button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add Ableton-style top bar with MIDI, BPM, audio device info, and global actions
- create configurable Global Settings modal for audio, MIDI, and fullscreen monitors
- introduce styles for new UI elements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Error failed to get cargo metadata: No such file or directory (os error 2))*


------
https://chatgpt.com/codex/tasks/task_e_68a5e95938f483338e6dd93f085bd588