### PR TITLE
fix: distribute glitch text across width

### DIFF
--- a/src/presets/text-glitch/config.json
+++ b/src/presets/text-glitch/config.json
@@ -18,7 +18,7 @@
     "opacity": 1.0,
     "fadeMs": 500,
     "text": {
-      "content": "R O B O T I C A",
+      "content": "ROBOTICA",
       "fontSize": 120,
       "fontFamily": "Arial Black, sans-serif",
       "letterSpacing": 0.3,
@@ -64,7 +64,7 @@
       "name": "text.content",
       "type": "text",
       "label": "Texto a Mostrar",
-      "default": "R O B O T I C A"
+      "default": "ROBOTICA"
     },
     {
       "name": "text.fontSize",

--- a/src/presets/text-glitch/preset.ts
+++ b/src/presets/text-glitch/preset.ts
@@ -303,27 +303,23 @@ class RoboticaCinematicPreset extends BasePreset {
   }
 
   private createCinematicText(): void {
-    const text = this.currentConfig.text.content;
+    const rawText = this.currentConfig.text.content;
+    const letters = rawText.replace(/\s+/g, '').split('');
     const fontSize = this.currentConfig.text.fontSize;
     const fontFamily = this.currentConfig.text.fontFamily;
-    const letterSpacing = this.currentConfig.text.letterSpacing;
     const scale = this.currentConfig.text.scale;
 
-    // Calcular espaciado total del texto
-    const letterWidth = fontSize * 0.8; // Aproximación del ancho de letra en px
-    const spacing = letterWidth * letterSpacing;
-    const totalWidth = (text.length - 1) * spacing;
-    
-    // Posición inicial centrada
-    const startX = -totalWidth / 2;
+    const letterWidth = fontSize * 0.8; // Aproximación del ancho de cada letra en px
+    const availableWidth = (this.currentConfig.width || 1920) * 0.9375; // Usar el 94% del ancho
+    const spacing = (availableWidth - letterWidth) / Math.max(letters.length - 1, 1);
+    const startX = -availableWidth / 2 + letterWidth / 2;
 
-    // Crear cada letra
-    for (let i = 0; i < text.length; i++) {
-      const char = text[i];
+    for (let i = 0; i < letters.length; i++) {
+      const char = letters[i];
       const x = startX + i * spacing;
       // Escalar coordenadas desde píxeles a unidades de Three.js
       const position = new THREE.Vector3((x / 100) * scale, 0, 0);
-      
+
       const letter = new CinematicLetter(char, fontSize, fontFamily, position);
       this.letters.push(letter);
       this.textGroup.add(letter.getMesh());


### PR DESCRIPTION
## Summary
- Normalize glitch text preset to strip spaces, measure available width and spread letters evenly across the visual
- Default glitch text preset content updated to "ROBOTICA"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Unable to find web assets)


------
https://chatgpt.com/codex/tasks/task_e_68a5ee7ed21c8333bd885e4dcb72229c