### PR TITLE
fix: externalize tauri window module

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,12 +13,13 @@ export default defineConfig({
       input: {
         main: './index.html',
       },
-      // Externalizar el módulo de Tauri para que no falle el build
-      external: ['@tauri-apps/api/event'],
+      // Externalizar los módulos de Tauri para que no falle el build
+      external: ['@tauri-apps/api/event', '@tauri-apps/api/window'],
       output: {
         // Configurar cómo manejar los módulos externos
         globals: {
-          '@tauri-apps/api/event': 'TauriEvent'
+          '@tauri-apps/api/event': 'TauriEvent',
+          '@tauri-apps/api/window': 'TauriWindow'
         }
       }
     }


### PR DESCRIPTION
## Summary
- externalize `@tauri-apps/api/window` in Vite config to avoid missing import during build

## Testing
- `npm run electron` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a603d107b083339dde6313db2d8dbf