### PR TITLE
fix tauri module resolution and add csp

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;" />
     <title>AudioVisualizer</title>
   </head>
   <body>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,15 +12,6 @@ export default defineConfig({
     rollupOptions: {
       input: {
         main: './index.html',
-      },
-      // Externalizar los módulos de Tauri para que no falle el build
-      external: ['@tauri-apps/api/event', '@tauri-apps/api/window'],
-      output: {
-        // Configurar cómo manejar los módulos externos
-        globals: {
-          '@tauri-apps/api/event': 'TauriEvent',
-          '@tauri-apps/api/window': 'TauriWindow'
-        }
       }
     }
   },


### PR DESCRIPTION
## Summary
- bundle Tauri API modules instead of leaving them external
- add content security policy meta tag to the app's HTML

## Testing
- `npx vite build`
- `npm run build` *(fails: the package 'audiovisualizer' does not contain this feature: custom-protocol)*

------
https://chatgpt.com/codex/tasks/task_e_68a6052013688333972eb03f4ae2664c