### PR TITLE
Add Boom Wave and customizable Glitch Text presets

### DIFF
--- a/App.ts
+++ b/App.ts
@@ -11,7 +11,7 @@ export class AudioVisualizerApp {
 
   constructor(container: HTMLElement) {
     this.initThreeJS(container);
-    this.presetLoader = new PresetLoader(this.scene, this.camera, this.renderer);
+      this.presetLoader = new PresetLoader(this.camera, this.renderer);
     this.init();
   }
 

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -10,16 +10,18 @@ interface GlobalSettingsModalProps {
   onClose: () => void;
   audioDevices: DeviceOption[];
   midiDevices: DeviceOption[];
-  selectedAudioId: string | null;
-  selectedMidiId: string | null;
-  onSelectAudio: (id: string) => void;
-  onSelectMidi: (id: string) => void;
-  audioGain: number;
-  onAudioGainChange: (value: number) => void;
-  monitors: DeviceOption[];
-  selectedMonitors: string[];
-  onToggleMonitor: (id: string) => void;
-}
+    selectedAudioId: string | null;
+    selectedMidiId: string | null;
+    onSelectAudio: (id: string) => void;
+    onSelectMidi: (id: string) => void;
+    audioGain: number;
+    onAudioGainChange: (value: number) => void;
+    monitors: DeviceOption[];
+    selectedMonitors: string[];
+    onToggleMonitor: (id: string) => void;
+    glitchTextPads: number;
+    onGlitchPadChange: (value: number) => void;
+  }
 
 export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   isOpen,
@@ -29,13 +31,15 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   selectedAudioId,
   selectedMidiId,
   onSelectAudio,
-  onSelectMidi,
-  audioGain,
-  onAudioGainChange,
-  monitors,
-  selectedMonitors,
-  onToggleMonitor
-}) => {
+    onSelectMidi,
+    audioGain,
+    onAudioGainChange,
+    monitors,
+    selectedMonitors,
+    onToggleMonitor,
+    glitchTextPads,
+    onGlitchPadChange
+  }) => {
   if (!isOpen) return null;
 
   return (
@@ -83,24 +87,38 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
               ))}
             </select>
           </label>
-        </div>
+          </div>
 
-        <div className="modal-section">
-          <h3>Full Screen Monitors</h3>
-          {monitors.map(mon => (
-            <label key={mon.id} className="monitor-option">
+          <div className="modal-section">
+            <h3>Full Screen Monitors</h3>
+            {monitors.map(mon => (
+              <label key={mon.id} className="monitor-option">
+                <input
+                  type="checkbox"
+                  checked={selectedMonitors.includes(mon.id)}
+                  onChange={() => onToggleMonitor(mon.id)}
+                />
+                {mon.label}
+              </label>
+            ))}
+          </div>
+
+          <div className="modal-section">
+            <h3>Global Visual Settings</h3>
+            <label>
+              Glitch text pads:
               <input
-                type="checkbox"
-                checked={selectedMonitors.includes(mon.id)}
-                onChange={() => onToggleMonitor(mon.id)}
+                type="number"
+                min={1}
+                max={8}
+                value={glitchTextPads}
+                onChange={(e) => onGlitchPadChange(parseInt(e.target.value))}
               />
-              {mon.label}
             </label>
-          ))}
-        </div>
+          </div>
 
-        <button onClick={onClose}>Cerrar</button>
+          <button onClick={onClose}>Cerrar</button>
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  };

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -14,7 +14,7 @@ export class AudioVisualizerEngine {
   private layerScenes: Map<string, THREE.Scene> = new Map();
   private layerOrder: string[] = ['C', 'B', 'A'];
 
-  constructor(private canvas: HTMLCanvasElement) {
+  constructor(private canvas: HTMLCanvasElement, options: { glitchTextPads?: number } = {}) {
     this.camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
     this.renderer = new THREE.WebGLRenderer({
       canvas: this.canvas,
@@ -33,7 +33,7 @@ export class AudioVisualizerEngine {
       this.layerScenes.set(id, scene);
     });
 
-    this.presetLoader = new PresetLoader(this.camera, this.renderer);
+      this.presetLoader = new PresetLoader(this.camera, this.renderer, options.glitchTextPads ?? 1);
     this.setupScene();
     this.setupEventListeners();
   }
@@ -178,6 +178,12 @@ export class AudioVisualizerEngine {
     this.presetLoader.dispose();
     this.layerPresets.clear();
     await this.presetLoader.loadAllPresets();
+  }
+
+  public async updateGlitchPadCount(count: number): Promise<LoadedPreset[]> {
+    this.presetLoader.setGlitchTextPads(count);
+    await this.reloadPresets();
+    return this.presetLoader.getLoadedPresets();
   }
 
   public dispose(): void {

--- a/src/presets/boom-wave/config.json
+++ b/src/presets/boom-wave/config.json
@@ -1,0 +1,45 @@
+{
+  "name": "Boom Wave",
+  "description": "Circular shock waves triggered by sub-bass booms",
+  "author": "AudioVisualizer",
+  "version": "1.0.0",
+  "category": "one-shot",
+  "tags": ["wave", "bass", "one-shot"],
+  "thumbnail": "boom_wave_thumb.png",
+  "defaultConfig": {
+    "opacity": 1.0,
+    "fadeMs": 200,
+    "color": "#00aaff",
+    "maxRadius": 5,
+    "waveDuration": 1.5,
+    "threshold": 0.8
+  },
+  "controls": [
+    {"name": "color", "type": "color", "label": "Color", "default": "#00aaff"},
+    {"name": "maxRadius", "type": "slider", "label": "Max Radius", "min": 1, "max": 10, "step": 0.5, "default": 5},
+    {"name": "waveDuration", "type": "slider", "label": "Duration", "min": 0.5, "max": 3, "step": 0.1, "default": 1.5},
+    {"name": "threshold", "type": "slider", "label": "Trigger Threshold", "min": 0, "max": 1, "step": 0.01, "default": 0.8}
+  ],
+  "audioMapping": {
+    "low": {
+      "description": "Triggers waves when bass peaks",
+      "frequency": "20-250 Hz",
+      "effect": "Wave spawn"
+    },
+    "mid": {
+      "description": "Modulates color intensity",
+      "frequency": "250-4000 Hz",
+      "effect": "Color modulation"
+    },
+    "high": {
+      "description": "Adds subtle brightness",
+      "frequency": "4000+ Hz",
+      "effect": "Brightness"
+    }
+  },
+  "performance": {
+    "complexity": "low",
+    "recommendedFPS": 60,
+    "gpuIntensive": false
+  }
+}

--- a/src/presets/boom-wave/preset.ts
+++ b/src/presets/boom-wave/preset.ts
@@ -1,0 +1,145 @@
+import * as THREE from 'three';
+import { BasePreset, PresetConfig } from '../../core/PresetLoader';
+
+export const config: PresetConfig = {
+  name: 'Boom Wave',
+  description: 'Circular shock waves triggered by sub-bass booms',
+  author: 'AudioVisualizer',
+  version: '1.0.0',
+  category: 'one-shot',
+  tags: ['wave', 'bass', 'one-shot'],
+  thumbnail: 'boom_wave_thumb.png',
+  defaultConfig: {
+    opacity: 1.0,
+    fadeMs: 200,
+    color: '#00aaff',
+    maxRadius: 5,
+    waveDuration: 1.5,
+    threshold: 0.8
+  },
+  controls: [
+    { name: 'color', type: 'color', label: 'Color', default: '#00aaff' },
+    { name: 'maxRadius', type: 'slider', label: 'Max Radius', min: 1, max: 10, step: 0.5, default: 5 },
+    { name: 'waveDuration', type: 'slider', label: 'Duration', min: 0.5, max: 3, step: 0.1, default: 1.5 },
+    { name: 'threshold', type: 'slider', label: 'Trigger Threshold', min: 0, max: 1, step: 0.01, default: 0.8 }
+  ],
+  audioMapping: {
+    low: { description: 'Triggers waves when bass peaks', frequency: '20-250 Hz', effect: 'Wave spawn' },
+    mid: { description: 'Modulates color intensity', frequency: '250-4000 Hz', effect: 'Color modulation' },
+    high: { description: 'Adds subtle brightness', frequency: '4000+ Hz', effect: 'Brightness' }
+  },
+  performance: { complexity: 'low', recommendedFPS: 60, gpuIntensive: false }
+};
+
+interface Wave {
+  mesh: THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>;
+  start: number;
+}
+
+class BoomWavePreset extends BasePreset {
+  private waves: Wave[] = [];
+  private currentConfig: any;
+  private lastSpawn = 0;
+
+  constructor(scene: THREE.Scene, camera: THREE.Camera, renderer: THREE.WebGLRenderer, cfg: PresetConfig) {
+    super(scene, camera, renderer, cfg);
+  }
+
+  public init(): void {
+    this.currentConfig = JSON.parse(JSON.stringify(this.config.defaultConfig));
+  }
+
+  private spawnWave(): void {
+    const geometry = new THREE.PlaneGeometry(1, 1);
+    const material = new THREE.ShaderMaterial({
+      transparent: true,
+      uniforms: {
+        uColor: { value: new THREE.Color(this.currentConfig.color) },
+        uProgress: { value: 0 }
+      },
+      vertexShader: `
+        varying vec2 vUv;
+        void main(){
+          vUv = uv;
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+        }
+      `,
+      fragmentShader: `
+        varying vec2 vUv;
+        uniform vec3 uColor;
+        uniform float uProgress;
+        void main(){
+          float dist = length(vUv - vec2(0.5));
+          float alpha = smoothstep(uProgress, uProgress + 0.05, dist) * (1.0 - uProgress);
+          gl_FragColor = vec4(uColor, alpha);
+        }
+      `
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.set((Math.random()-0.5)*2, (Math.random()-0.5)*2, 0);
+    this.scene.add(mesh);
+    this.waves.push({ mesh, start: this.clock.getElapsedTime() });
+  }
+
+  public update(): void {
+    const t = this.clock.getElapsedTime();
+    const delta = this.clock.getDelta();
+    if (this.audioData.low > this.currentConfig.threshold && t - this.lastSpawn > 0.1) {
+      this.spawnWave();
+      this.lastSpawn = t;
+    }
+
+    const duration = this.currentConfig.waveDuration;
+    const maxRadius = this.currentConfig.maxRadius;
+
+    this.waves = this.waves.filter(w => {
+      const progress = (t - w.start) / duration;
+      if (progress > 1) {
+        this.scene.remove(w.mesh);
+        w.mesh.geometry.dispose();
+        w.mesh.material.dispose();
+        return false;
+      }
+      w.mesh.scale.setScalar(progress * maxRadius);
+      const mat = w.mesh.material as THREE.ShaderMaterial;
+      mat.uniforms.uProgress.value = progress;
+      mat.uniforms.uColor.value.set(this.currentConfig.color);
+      return true;
+    });
+  }
+
+  public updateConfig(newConfig: any): void {
+    this.currentConfig = this.deepMerge(this.currentConfig, newConfig);
+  }
+
+  private deepMerge(target: any, source: any): any {
+    const result = { ...target };
+    for (const key in source) {
+      if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+        result[key] = this.deepMerge(result[key] || {}, source[key]);
+      } else {
+        result[key] = source[key];
+      }
+    }
+    return result;
+  }
+
+  public dispose(): void {
+    this.waves.forEach(w => {
+      this.scene.remove(w.mesh);
+      w.mesh.geometry.dispose();
+      w.mesh.material.dispose();
+    });
+    this.waves = [];
+  }
+}
+
+export function createPreset(
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  renderer: THREE.WebGLRenderer,
+  cfg: PresetConfig,
+  shaderCode?: string
+): BasePreset {
+  return new BoomWavePreset(scene, camera, renderer, cfg);
+}

--- a/src/presets/custom-glitch-text/config.json
+++ b/src/presets/custom-glitch-text/config.json
@@ -1,0 +1,52 @@
+{
+  "name": "Custom Glitch Text",
+  "description": "Text with configurable glitch effect",
+  "author": "AudioVisualizer",
+  "version": "1.0.0",
+  "category": "text",
+  "tags": ["text", "glitch", "one-shot"],
+  "thumbnail": "custom_glitch_text_thumb.png",
+  "defaultConfig": {
+    "opacity": 1.0,
+    "fadeMs": 200,
+    "text": {
+      "content": "TEXT",
+      "fontSize": 120,
+      "fontFamily": "Arial Black, sans-serif"
+    },
+    "glitch": {
+      "intensity": 0.05,
+      "frequency": 2.0
+    },
+    "color": "#ffffff"
+  },
+  "controls": [
+    {"name": "text.content", "type": "text", "label": "Text", "default": "TEXT"},
+    {"name": "text.fontSize", "type": "slider", "label": "Font Size", "min": 40, "max": 200, "step": 10, "default": 120},
+    {"name": "glitch.intensity", "type": "slider", "label": "Glitch Intensity", "min": 0, "max": 0.5, "step": 0.01, "default": 0.05},
+    {"name": "glitch.frequency", "type": "slider", "label": "Glitch Frequency", "min": 0, "max": 10, "step": 0.1, "default": 2.0},
+    {"name": "color", "type": "color", "label": "Color", "default": "#ffffff"}
+  ],
+  "audioMapping": {
+    "low": {
+      "description": "Slight scale bump",
+      "frequency": "20-250 Hz",
+      "effect": "Scale"
+    },
+    "mid": {
+      "description": "Glitch trigger",
+      "frequency": "250-4000 Hz",
+      "effect": "Glitch randomness"
+    },
+    "high": {
+      "description": "Color flicker",
+      "frequency": "4000+ Hz",
+      "effect": "Color shift"
+    }
+  },
+  "performance": {
+    "complexity": "low",
+    "recommendedFPS": 60,
+    "gpuIntensive": false
+  }
+}

--- a/src/presets/custom-glitch-text/preset.ts
+++ b/src/presets/custom-glitch-text/preset.ts
@@ -1,0 +1,142 @@
+import * as THREE from 'three';
+import { BasePreset, PresetConfig } from '../../core/PresetLoader';
+
+export const config: PresetConfig = {
+  name: 'Custom Glitch Text',
+  description: 'Text with configurable glitch effect',
+  author: 'AudioVisualizer',
+  version: '1.0.0',
+  category: 'text',
+  tags: ['text', 'glitch', 'one-shot'],
+  thumbnail: 'custom_glitch_text_thumb.png',
+  defaultConfig: {
+    opacity: 1.0,
+    fadeMs: 200,
+    text: {
+      content: 'TEXT',
+      fontSize: 120,
+      fontFamily: 'Arial Black, sans-serif'
+    },
+    glitch: {
+      intensity: 0.05,
+      frequency: 2.0
+    },
+    color: '#ffffff'
+  },
+  controls: [
+    { name: 'text.content', type: 'text', label: 'Text', default: 'TEXT' },
+    { name: 'text.fontSize', type: 'slider', label: 'Font Size', min: 40, max: 200, step: 10, default: 120 },
+    { name: 'glitch.intensity', type: 'slider', label: 'Glitch Intensity', min: 0, max: 0.5, step: 0.01, default: 0.05 },
+    { name: 'glitch.frequency', type: 'slider', label: 'Glitch Frequency', min: 0, max: 10, step: 0.1, default: 2.0 },
+    { name: 'color', type: 'color', label: 'Color', default: '#ffffff' }
+  ],
+  audioMapping: {
+    low: { description: 'Slight scale bump', frequency: '20-250 Hz', effect: 'Scale' },
+    mid: { description: 'Glitch trigger', frequency: '250-4000 Hz', effect: 'Glitch randomness' },
+    high: { description: 'Color flicker', frequency: '4000+ Hz', effect: 'Color shift' }
+  },
+  performance: { complexity: 'low', recommendedFPS: 60, gpuIntensive: false }
+};
+
+class CustomGlitchTextPreset extends BasePreset {
+  private group!: THREE.Group;
+  private mesh!: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial>;
+  private canvas!: HTMLCanvasElement;
+  private ctx!: CanvasRenderingContext2D;
+  private texture!: THREE.Texture;
+  private currentConfig: any;
+
+  constructor(scene: THREE.Scene, camera: THREE.Camera, renderer: THREE.WebGLRenderer, cfg: PresetConfig) {
+    super(scene, camera, renderer, cfg);
+  }
+
+  public init(): void {
+    this.currentConfig = JSON.parse(JSON.stringify(this.config.defaultConfig));
+    this.group = new THREE.Group();
+    this.scene.add(this.group);
+
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = 1024;
+    this.canvas.height = 256;
+    this.ctx = this.canvas.getContext('2d')!;
+
+    this.texture = new THREE.Texture(this.canvas);
+    this.texture.needsUpdate = true;
+
+    this.mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(2, 0.5),
+      new THREE.MeshBasicMaterial({ map: this.texture, transparent: true, color: new THREE.Color(this.currentConfig.color) })
+    );
+    this.group.add(this.mesh);
+
+    this.updateCanvas();
+  }
+
+  private updateCanvas(): void {
+    const { content, fontSize, fontFamily } = this.currentConfig.text;
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.ctx.fillStyle = '#ffffff';
+    this.ctx.font = `${fontSize}px ${fontFamily}`;
+    this.ctx.textAlign = 'center';
+    this.ctx.textBaseline = 'middle';
+    this.ctx.fillText(content, this.canvas.width / 2, this.canvas.height / 2);
+    this.texture.needsUpdate = true;
+  }
+
+  public update(): void {
+    const delta = this.clock.getDelta();
+    const { intensity, frequency } = this.currentConfig.glitch;
+
+    if (Math.random() < frequency * delta) {
+      this.mesh.position.x = (Math.random() - 0.5) * intensity;
+      this.mesh.position.y = (Math.random() - 0.5) * intensity;
+      this.mesh.material.color.setHSL(Math.random(), 1, 0.5);
+    } else {
+      this.mesh.position.set(0, 0, 0);
+      this.mesh.material.color.set(this.currentConfig.color);
+    }
+
+    const scaleBump = 1 + this.audioData.low * 0.1;
+    this.group.scale.setScalar(scaleBump);
+  }
+
+  public updateConfig(newConfig: any): void {
+    this.currentConfig = this.deepMerge(this.currentConfig, newConfig);
+    if (newConfig.text) {
+      this.updateCanvas();
+    }
+    if (newConfig.color) {
+      this.mesh.material.color.set(newConfig.color);
+    }
+  }
+
+  private deepMerge(target: any, source: any): any {
+    const result = { ...target };
+    for (const key in source) {
+      if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+        result[key] = this.deepMerge(result[key] || {}, source[key]);
+      } else {
+        result[key] = source[key];
+      }
+    }
+    return result;
+  }
+
+  public dispose(): void {
+    this.group.remove(this.mesh);
+    this.scene.remove(this.group);
+    this.mesh.geometry.dispose();
+    this.mesh.material.dispose();
+    this.texture.dispose();
+  }
+}
+
+export function createPreset(
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  renderer: THREE.WebGLRenderer,
+  cfg: PresetConfig,
+  shaderCode?: string
+): BasePreset {
+  return new CustomGlitchTextPreset(scene, camera, renderer, cfg);
+}


### PR DESCRIPTION
## Summary
- add Boom Wave one-shot preset with bass-triggered shock waves
- add Custom Glitch Text preset with adjustable text and glitch controls
- introduce global visual settings to configure number of glitch text pads

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Unable to find web assets)


------
https://chatgpt.com/codex/tasks/task_e_68a60673f914833380b8d2b589d53c12