### PR TITLE
Display MIDI note number on preset pads

### DIFF
--- a/src/presets/abstract-lines/preset.ts
+++ b/src/presets/abstract-lines/preset.ts
@@ -9,6 +9,7 @@ export const config: PresetConfig = {
   category: "abstract",
   tags: ["abstract", "lines", "procedural", "performance", "generative"],
   thumbnail: "abstract_lines_pro_thumb.png",
+  note: 55,
   defaultConfig: {
     opacity: 1.0,
     fadeMs: 200,

--- a/src/presets/boom-wave/preset.ts
+++ b/src/presets/boom-wave/preset.ts
@@ -9,6 +9,7 @@ export const config: PresetConfig = {
   category: 'one-shot',
   tags: ['wave', 'bass', 'one-shot'],
   thumbnail: 'boom_wave_thumb.png',
+  note: 58,
   defaultConfig: {
     opacity: 1.0,
     fadeMs: 200,

--- a/src/presets/custom-glitch-text/preset.ts
+++ b/src/presets/custom-glitch-text/preset.ts
@@ -9,6 +9,7 @@ export const config: PresetConfig = {
   category: 'text',
   tags: ['text', 'glitch', 'one-shot'],
   thumbnail: 'custom_glitch_text_thumb.png',
+  note: 59,
   defaultConfig: {
     opacity: 1.0,
     fadeMs: 200,

--- a/src/presets/evolutive-particles/preset.ts
+++ b/src/presets/evolutive-particles/preset.ts
@@ -10,6 +10,7 @@ export const config: PresetConfig = {
   category: "particles",
   tags: ["particles", "evolution", "organic", "complex", "adaptive", "swarm"],
   thumbnail: "evolutive_particles_thumb.png",
+  note: 56,
   defaultConfig: {
     opacity: 1.0,
     fadeMs: 250,

--- a/src/presets/neural_network/preset.ts
+++ b/src/presets/neural_network/preset.ts
@@ -9,6 +9,7 @@ export const config: PresetConfig = {
   category: 'ai',
   tags: ['neural', 'network', 'infinite', 'starfield'],
   thumbnail: 'neural_network_thumb.png',
+  note: 54,
   defaultConfig: {
     speed: 5,
     nodeSize: 0.05,

--- a/src/presets/plasma-ray/preset.ts
+++ b/src/presets/plasma-ray/preset.ts
@@ -9,6 +9,7 @@ export const config: PresetConfig = {
   category: "energy",
   tags: ["energy", "wave", "flow", "horizontal", "plasma", "smooth"],
   thumbnail: "energy_wave_ray_thumb.png",
+  note: 57,
   defaultConfig: {
     opacity: 1.0,
     fadeMs: 100,

--- a/src/presets/shot-text/preset.ts
+++ b/src/presets/shot-text/preset.ts
@@ -10,6 +10,7 @@ export const config: PresetConfig = {
   category: "text",
   tags: ["text", "intro", "robotica", "cinematic", "glow", "animation"],
   thumbnail: "robotica_intro_thumb.png",
+  note: 60,
   defaultConfig: {
     opacity: 1.0,
     fadeMs: 200,

--- a/src/presets/text-glitch/preset.ts
+++ b/src/presets/text-glitch/preset.ts
@@ -10,6 +10,7 @@ export const config: PresetConfig = {
   category: "text",
   tags: ["text", "intro", "robotica", "cinematic", "title"],
   thumbnail: "robotica_cinematic_thumb.png",
+  note: 61,
   defaultConfig: {
     opacity: 1.0,
     fadeMs: 200,


### PR DESCRIPTION
## Summary
- add `note` property to each preset config so MIDI note numbers render on pad badges

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a6208bd2188333b7c2a0d6f76b050d