### PR TITLE
feat: auto-detect presets and assign notes

### DIFF
--- a/src/presets/boom-wave/config.json
+++ b/src/presets/boom-wave/config.json
@@ -13,13 +13,15 @@
     "color": "#00aaff",
     "maxRadius": 5,
     "waveDuration": 1.5,
-    "threshold": 0.8
+    "threshold": 0.8,
+    "spawnSpread": 2
   },
   "controls": [
     {"name": "color", "type": "color", "label": "Color", "default": "#00aaff"},
     {"name": "maxRadius", "type": "slider", "label": "Max Radius", "min": 1, "max": 10, "step": 0.5, "default": 5},
     {"name": "waveDuration", "type": "slider", "label": "Duration", "min": 0.5, "max": 3, "step": 0.1, "default": 1.5},
-    {"name": "threshold", "type": "slider", "label": "Trigger Threshold", "min": 0, "max": 1, "step": 0.01, "default": 0.8}
+    {"name": "threshold", "type": "slider", "label": "Trigger Threshold", "min": 0, "max": 1, "step": 0.01, "default": 0.8},
+    {"name": "spawnSpread", "type": "slider", "label": "Spawn Spread", "min": 0, "max": 5, "step": 0.1, "default": 2}
   ],
   "audioMapping": {
     "low": {

--- a/src/presets/boom-wave/preset.ts
+++ b/src/presets/boom-wave/preset.ts
@@ -16,13 +16,15 @@ export const config: PresetConfig = {
     color: '#00aaff',
     maxRadius: 5,
     waveDuration: 1.5,
-    threshold: 0.8
+    threshold: 0.8,
+    spawnSpread: 2
   },
   controls: [
     { name: 'color', type: 'color', label: 'Color', default: '#00aaff' },
     { name: 'maxRadius', type: 'slider', label: 'Max Radius', min: 1, max: 10, step: 0.5, default: 5 },
     { name: 'waveDuration', type: 'slider', label: 'Duration', min: 0.5, max: 3, step: 0.1, default: 1.5 },
-    { name: 'threshold', type: 'slider', label: 'Trigger Threshold', min: 0, max: 1, step: 0.01, default: 0.8 }
+    { name: 'threshold', type: 'slider', label: 'Trigger Threshold', min: 0, max: 1, step: 0.01, default: 0.8 },
+    { name: 'spawnSpread', type: 'slider', label: 'Spawn Spread', min: 0, max: 5, step: 0.1, default: 2 }
   ],
   audioMapping: {
     low: { description: 'Triggers waves when bass peaks', frequency: '20-250 Hz', effect: 'Wave spawn' },
@@ -47,6 +49,7 @@ class BoomWavePreset extends BasePreset {
   }
 
   public init(): void {
+    this.renderer.setClearColor(0x000000, 0);
     this.currentConfig = JSON.parse(JSON.stringify(this.config.defaultConfig));
   }
 
@@ -77,7 +80,8 @@ class BoomWavePreset extends BasePreset {
       `
     });
     const mesh = new THREE.Mesh(geometry, material);
-    mesh.position.set((Math.random()-0.5)*2, (Math.random()-0.5)*2, 0);
+    const spread = this.currentConfig.spawnSpread || 0;
+    mesh.position.set((Math.random()-0.5)*spread, (Math.random()-0.5)*spread, 0);
     this.scene.add(mesh);
     this.waves.push({ mesh, start: this.clock.getElapsedTime() });
   }


### PR DESCRIPTION
## Summary
- auto-detect presets via Vite glob imports
- assign next free MIDI note to presets without one and persist to config
- enhance Boom Wave preset with spawn spread control and transparency fix

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a62351b7188333a242998a263f3fda