### PR TITLE
Fix selector visibility and clear all behaviour

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ const App: React.FC = () => {
   const [monitors, setMonitors] = useState<MonitorInfo[]>([]);
   const [selectedMonitors, setSelectedMonitors] = useState<string[]>([]);
   const [glitchTextPads, setGlitchTextPads] = useState<number>(() => parseInt(localStorage.getItem('glitchTextPads') || '1'));
+  const [clearSignal, setClearSignal] = useState(0);
   const isFullscreenMode = new URLSearchParams(window.location.search).get('fullscreen') === 'true';
 
   // Persist selected devices across sessions
@@ -473,8 +474,12 @@ const App: React.FC = () => {
 
   const handleClearAll = () => {
     if (!engineRef.current) return;
-    Object.keys(activeLayers).forEach(layerId => engineRef.current?.deactivateLayerPreset(layerId));
+    ['A', 'B', 'C'].forEach(layerId => engineRef.current?.deactivateLayerPreset(layerId));
+    engineRef.current.clearRenderer();
     setActiveLayers({});
+    setSelectedPreset(null);
+    setSelectedLayer(null);
+    setClearSignal(prev => prev + 1);
     setStatus('Capas limpiadas');
   };
 
@@ -550,7 +555,7 @@ const App: React.FC = () => {
                 delete newLayers[layerId];
                 return newLayers;
               });
-              
+
               // Limpiar selección si se limpia el layer seleccionado
               if (selectedLayer === layerId) {
                 setSelectedPreset(null);
@@ -563,6 +568,21 @@ const App: React.FC = () => {
               engineRef.current.updateLayerConfig(layerId, config);
             }
           }}
+          onPresetSelect={(layerId, presetId) => {
+            if (presetId) {
+              const preset = availablePresets.find(p => p.id === presetId);
+              if (preset) {
+                setSelectedPreset(preset);
+                setSelectedLayer(layerId);
+              }
+            } else {
+              if (selectedLayer === layerId) {
+                setSelectedPreset(null);
+                setSelectedLayer(null);
+              }
+            }
+          }}
+          clearAllSignal={clearSignal}
         />
       </div>
 

--- a/src/components/GlobalSettingsModal.css
+++ b/src/components/GlobalSettingsModal.css
@@ -220,6 +220,12 @@
   box-shadow: 0 0 0 2px rgba(100, 181, 246, 0.2);
 }
 
+/* Ensure dropdown options are visible on dark theme */
+.setting-select option {
+  background: #333;
+  color: #fff;
+}
+
 .setting-slider {
   padding: 0;
   height: 8px;

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -177,11 +177,11 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
         {/* Tabs */}
         <div className="settings-tabs">
           {[
-            { id: 'audio', label: '🎵 Audio', icon: '🎵' },
-            { id: 'video', label: '🎮 Rendimiento', icon: '🎮' },
-            { id: 'fullscreen', label: '🖥️ Monitores', icon: '🖥️' },
-            { id: 'visual', label: '🎨 Visuales', icon: '🎨' },
-            { id: 'system', label: '🔧 Sistema', icon: '🔧' }
+            { id: 'audio', label: 'Audio', icon: '🎵' },
+            { id: 'video', label: 'Rendimiento', icon: '🎮' },
+            { id: 'fullscreen', label: 'Monitores', icon: '🖥️' },
+            { id: 'visual', label: 'Visuales', icon: '🎨' },
+            { id: 'system', label: 'Sistema', icon: '🔧' }
           ].map(tab => (
             <button
               key={tab.id}

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { LoadedPreset } from '../core/PresetLoader';
 
 interface LayerConfig {
@@ -17,6 +17,7 @@ interface LayerGridProps {
   onLayerClear: (layerId: string) => void;
   onLayerConfigChange: (layerId: string, config: Partial<LayerConfig>) => void;
   onPresetSelect: (layerId: string, presetId: string) => void;
+  clearAllSignal: number;
 }
 
 export const LayerGrid: React.FC<LayerGridProps> = ({
@@ -24,13 +25,19 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
   onPresetActivate,
   onLayerClear,
   onLayerConfigChange,
-  onPresetSelect
+  onPresetSelect,
+  clearAllSignal
 }) => {
   const [layers, setLayers] = useState<LayerConfig[]>([
     { id: 'A', name: 'Layer A', color: '#FF6B6B', midiChannel: 14, fadeTime: 200, opacity: 100, activePreset: null },
     { id: 'B', name: 'Layer B', color: '#4ECDC4', midiChannel: 15, fadeTime: 200, opacity: 100, activePreset: null },
     { id: 'C', name: 'Layer C', color: '#45B7D1', midiChannel: 16, fadeTime: 200, opacity: 100, activePreset: null },
   ]);
+
+  useEffect(() => {
+    setLayers(prev => prev.map(layer => ({ ...layer, activePreset: null })));
+    setClickedCell(null);
+  }, [clearAllSignal]);
 
   const [clickedCell, setClickedCell] = useState<string | null>(null);
 

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -363,15 +363,20 @@ export class AudioVisualizerEngine {
 
   public getLayerStatus(): Record<string, { active: boolean; preset: string | null }> {
     const status: Record<string, { active: boolean; preset: string | null }> = {};
-    
+
     this.layers.forEach((layer, layerId) => {
       status[layerId] = {
         active: layer.isActive,
         preset: layer.preset?.id || null
       };
     });
-    
+
     return status;
+  }
+
+  public clearRenderer(): void {
+    this.renderer.setClearColor(0x000000, 0);
+    this.renderer.clear(true, true, true);
   }
 
   public dispose(): void {


### PR DESCRIPTION
## Summary
- style all select dropdowns with dark background and light text
- show a single emoji per tab in settings modal
- clear visuals and reset grid when pressing **Clear All**

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68a62e71a5848333b572e240e18fccfa