### PR TITLE
feat: enable per-layer preset configuration

### DIFF
--- a/src/components/PresetControls.tsx
+++ b/src/components/PresetControls.tsx
@@ -3,14 +3,17 @@
 import React, { useEffect, useRef } from 'react';
 import { LoadedPreset } from '../core/PresetLoader';
 import './PresetControls.css';  // ✅ AÑADIR ESTE IMPORT
+import { getNestedValue } from '../utils/objectPath';
 
 interface PresetControlsProps {
   preset: LoadedPreset;
-  onConfigUpdate: (config: any) => void;
+  config: any;
+  onConfigUpdate: (path: string, value: any) => void;
 }
 
 export const PresetControls: React.FC<PresetControlsProps> = ({
   preset,
+  config,
   onConfigUpdate
 }) => {
   const contentRef = useRef<HTMLDivElement>(null);
@@ -31,7 +34,7 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
 
   const handleControlChange = (controlName: string, value: any, type: string) => {
     let processedValue = value;
-    
+
     switch (type) {
       case 'number':
       case 'slider':
@@ -50,13 +53,11 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
         break;
     }
 
-    onConfigUpdate({
-      [controlName]: processedValue
-    });
+    onConfigUpdate(controlName, processedValue);
   };
 
   const renderControl = (control: any) => {
-    const currentValue = preset.config.defaultConfig?.[control.name] || control.default;
+    const currentValue = getNestedValue(config, control.name) ?? control.default;
 
     switch (control.type) {
       case 'slider':
@@ -180,15 +181,15 @@ export const PresetControls: React.FC<PresetControlsProps> = ({
   };
 
   const basicControls = [
-    { name: 'width', type: 'number', label: 'Ancho', min: 100, max: 4096, default: preset.config.defaultConfig?.width || 1920 },
-    { name: 'height', type: 'number', label: 'Alto', min: 100, max: 4096, default: preset.config.defaultConfig?.height || 1080 },
-    { name: 'zoom', type: 'slider', label: 'Zoom', min: 0.1, max: 5, step: 0.1, default: preset.config.defaultConfig?.zoom || 1 },
+    { name: 'width', type: 'number', label: 'Ancho', min: 100, max: 4096, default: getNestedValue(config, 'width') ?? preset.config.defaultConfig?.width ?? 1920 },
+    { name: 'height', type: 'number', label: 'Alto', min: 100, max: 4096, default: getNestedValue(config, 'height') ?? preset.config.defaultConfig?.height ?? 1080 },
+    { name: 'zoom', type: 'slider', label: 'Zoom', min: 0.1, max: 5, step: 0.1, default: getNestedValue(config, 'zoom') ?? preset.config.defaultConfig?.zoom ?? 1 },
   ];
 
   const audioControls = [
-    { name: 'audioSensitivity', type: 'slider', label: 'Sensibilidad', min: 0, max: 2, step: 0.01, default: preset.config.defaultConfig?.audioSensitivity || 1 },
-    { name: 'audioSmoothness', type: 'slider', label: 'Suavizado', min: 0, max: 1, step: 0.01, default: preset.config.defaultConfig?.audioSmoothness || 0.5 },
-    { name: 'audioReactivity', type: 'slider', label: 'Reactividad', min: 0, max: 2, step: 0.01, default: preset.config.defaultConfig?.audioReactivity || 1 },
+    { name: 'audioSensitivity', type: 'slider', label: 'Sensibilidad', min: 0, max: 2, step: 0.01, default: getNestedValue(config, 'audioSensitivity') ?? preset.config.defaultConfig?.audioSensitivity ?? 1 },
+    { name: 'audioSmoothness', type: 'slider', label: 'Suavizado', min: 0, max: 1, step: 0.01, default: getNestedValue(config, 'audioSmoothness') ?? preset.config.defaultConfig?.audioSmoothness ?? 0.5 },
+    { name: 'audioReactivity', type: 'slider', label: 'Reactividad', min: 0, max: 2, step: 0.01, default: getNestedValue(config, 'audioReactivity') ?? preset.config.defaultConfig?.audioReactivity ?? 1 },
   ];
 
   return (

--- a/src/core/PresetLoader.ts
+++ b/src/core/PresetLoader.ts
@@ -244,7 +244,12 @@ export interface LoadedPreset {
     }
   }
 
-  public activatePreset(presetId: string, scene: THREE.Scene, instanceId: string): BasePreset | null {
+  public activatePreset(
+    presetId: string,
+    scene: THREE.Scene,
+    instanceId: string,
+    configOverride?: PresetConfig
+  ): BasePreset | null {
     const loadedPreset = this.loadedPresets.get(presetId);
     if (!loadedPreset) {
       console.error(`Preset ${presetId} not found`);
@@ -258,14 +263,14 @@ export interface LoadedPreset {
         scene,
         this.camera,
         this.renderer,
-        loadedPreset.config,
+        configOverride ?? loadedPreset.config,
         loadedPreset.shaderCode
       );
 
       presetInstance.init();
       this.activePresets.set(instanceId, presetInstance);
 
-      console.log(`🎨 Activated preset: ${loadedPreset.config.name}`);
+      console.log(`🎨 Activated preset: ${(configOverride ?? loadedPreset.config).name}`);
       return presetInstance;
     } catch (error) {
       console.error(`Failed to activate preset ${presetId}:`, error);

--- a/src/utils/objectPath.ts
+++ b/src/utils/objectPath.ts
@@ -1,0 +1,18 @@
+export function getNestedValue(obj: any, path: string): any {
+  if (!obj) return undefined;
+  return path.split('.').reduce((o, key) => (o ? o[key] : undefined), obj);
+}
+
+export function setNestedValue(obj: any, path: string, value: any): void {
+  const keys = path.split('.');
+  const lastKey = keys.pop();
+  if (!lastKey) return;
+  let current = obj;
+  for (const key of keys) {
+    if (current[key] === undefined) {
+      current[key] = {};
+    }
+    current = current[key];
+  }
+  current[lastKey] = value;
+}


### PR DESCRIPTION
## Summary
- track preset settings per layer and expose helpers for nested values
- persist layer-specific configuration to disk and load when activating presets
- wire sidebar controls to update presets in real time

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6341059c483338017cc8c0b7a47d0