### PR TITLE
Improve MIDI clock BPM handling and MIDI settings

### DIFF
--- a/src/components/GlobalSettingsModal.css
+++ b/src/components/GlobalSettingsModal.css
@@ -212,6 +212,20 @@
   transition: all 0.2s ease;
 }
 
+.layer-channel-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.layer-channel-settings h5 {
+  margin: 0;
+  font-size: 14px;
+  color: #ccc;
+  font-weight: 500;
+}
+
 .setting-select:focus,
 .setting-slider:focus,
 .setting-number:focus {

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -28,6 +28,12 @@ interface GlobalSettingsModalProps {
   onSelectMidi: (id: string) => void;
   audioGain: number;
   onAudioGainChange: (value: number) => void;
+  midiClockDelay: number;
+  onMidiClockDelayChange: (value: number) => void;
+  midiClockType: string;
+  onMidiClockTypeChange: (value: string) => void;
+  layerChannels: Record<string, number>;
+  onLayerChannelChange: (layerId: string, channel: number) => void;
   monitors: MonitorInfo[];
   selectedMonitors: string[];
   onToggleMonitor: (id: string) => void;
@@ -46,6 +52,12 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   onSelectMidi,
   audioGain,
   onAudioGainChange,
+  midiClockDelay,
+  onMidiClockDelayChange,
+  midiClockType,
+  onMidiClockTypeChange,
+  layerChannels,
+  onLayerChannelChange,
   monitors,
   selectedMonitors,
   onToggleMonitor,
@@ -294,6 +306,44 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
                     ))}
                   </select>
                 </label>
+                <label className="setting-label">
+                  <span>Tipo de Clock</span>
+                  <select
+                    value={midiClockType}
+                    onChange={(e) => onMidiClockTypeChange(e.target.value)}
+                    className="setting-select"
+                  >
+                    <option value="midi">MIDI</option>
+                    <option value="off">Off</option>
+                  </select>
+                </label>
+                <label className="setting-label">
+                  <span>Delay Clock (ms)</span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={1000}
+                    value={midiClockDelay}
+                    onChange={(e) => onMidiClockDelayChange(parseInt(e.target.value) || 0)}
+                    className="setting-number"
+                  />
+                </label>
+                <div className="layer-channel-settings">
+                  <h5>Canal MIDI por Layer</h5>
+                  {['A','B','C'].map(id => (
+                    <label key={id} className="setting-label">
+                      <span>Layer {id}</span>
+                      <input
+                        type="number"
+                        min={1}
+                        max={16}
+                        value={layerChannels[id]}
+                        onChange={(e) => onLayerChannelChange(id, parseInt(e.target.value) || 1)}
+                        className="setting-number"
+                      />
+                    </label>
+                  ))}
+                </div>
               </div>
             </div>
           )}

--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -44,6 +44,11 @@
   font-weight: 600;
 }
 
+.midi-channel-label {
+  font-size: 10px;
+  color: #bbb;
+}
+
 .sidebar-controls {
   display: flex;
   flex-direction: column;

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -19,6 +19,7 @@ interface LayerGridProps {
   onPresetSelect: (layerId: string, presetId: string) => void;
   clearAllSignal: number;
   externalTrigger?: { layerId: string; presetId: string } | null;
+  layerChannels: Record<string, number>;
 }
 
 export const LayerGrid: React.FC<LayerGridProps> = ({
@@ -28,12 +29,13 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
   onLayerConfigChange,
   onPresetSelect,
   clearAllSignal,
-  externalTrigger
+  externalTrigger,
+  layerChannels
 }) => {
   const [layers, setLayers] = useState<LayerConfig[]>([
-    { id: 'A', name: 'Layer A', color: '#FF6B6B', midiChannel: 14, fadeTime: 200, opacity: 100, activePreset: null },
-    { id: 'B', name: 'Layer B', color: '#4ECDC4', midiChannel: 15, fadeTime: 200, opacity: 100, activePreset: null },
-    { id: 'C', name: 'Layer C', color: '#45B7D1', midiChannel: 16, fadeTime: 200, opacity: 100, activePreset: null },
+    { id: 'A', name: 'Layer A', color: '#FF6B6B', midiChannel: layerChannels.A || 14, fadeTime: 200, opacity: 100, activePreset: null },
+    { id: 'B', name: 'Layer B', color: '#4ECDC4', midiChannel: layerChannels.B || 15, fadeTime: 200, opacity: 100, activePreset: null },
+    { id: 'C', name: 'Layer C', color: '#45B7D1', midiChannel: layerChannels.C || 16, fadeTime: 200, opacity: 100, activePreset: null },
   ]);
 
   useEffect(() => {
@@ -94,6 +96,13 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [externalTrigger]);
 
+  useEffect(() => {
+    setLayers(prev => prev.map(layer => ({
+      ...layer,
+      midiChannel: layerChannels[layer.id] || layer.midiChannel
+    })));
+  }, [layerChannels]);
+
   const getPresetThumbnail = (preset: LoadedPreset): string => {
     // Generar thumbnail basado en categoría/tipo
     const thumbnails: Record<string, string> = {
@@ -122,6 +131,7 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
             <div className="layer-letter" style={{ color: layer.color }}>
               {layer.id}
             </div>
+            <div className="midi-channel-label">CH {layer.midiChannel}</div>
             <div className="sidebar-controls">
               <input
                 type="range"


### PR DESCRIPTION
## Summary
- Smooth BPM calculation with MIDI clock start/stop handling and optional delay
- Add settings for MIDI clock type, delay and per-layer MIDI channels
- Show each layer's MIDI channel and honor custom channels for triggers

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a639438e808333b9a25410fed1dd11