### PR TITLE
Add heart beat and soft flare one-shot presets

### DIFF
--- a/src/presets/heart-beat/config.json
+++ b/src/presets/heart-beat/config.json
@@ -1,0 +1,31 @@
+{
+  "name": "Heart Beat",
+  "description": "Pulse of a grayscale electronic heart",
+  "author": "AudioVisualizer",
+  "version": "1.0.0",
+  "category": "one-shot",
+  "tags": ["heart", "pulse", "one-shot"],
+  "thumbnail": "heart_beat_thumb.png",
+  "note": 62,
+  "defaultConfig": {
+    "opacity": 1.0,
+    "duration": 1.5,
+    "color": "#ffffff",
+    "scale": 1.0
+  },
+  "controls": [
+    {"name": "color", "type": "color", "label": "Color", "default": "#ffffff"},
+    {"name": "duration", "type": "slider", "label": "Duration", "min": 0.5, "max": 3, "step": 0.1, "default": 1.5},
+    {"name": "scale", "type": "slider", "label": "Scale", "min": 0.5, "max": 2, "step": 0.1, "default": 1.0}
+  ],
+  "audioMapping": {
+    "low": {"description": "Triggers heart beat", "frequency": "20-250 Hz", "effect": "Pulse amplitude"},
+    "mid": {"description": "Modulates glow", "frequency": "250-4000 Hz", "effect": "Glow intensity"},
+    "high": {"description": "Adds shimmer", "frequency": "4000+ Hz", "effect": "Subtle flicker"}
+  },
+  "performance": {
+    "complexity": "low",
+    "recommendedFPS": 60,
+    "gpuIntensive": false
+  }
+}

--- a/src/presets/heart-beat/preset.ts
+++ b/src/presets/heart-beat/preset.ts
@@ -1,0 +1,108 @@
+import * as THREE from 'three';
+import { BasePreset, PresetConfig } from '../../core/PresetLoader';
+
+export const config: PresetConfig = {
+  name: 'Heart Beat',
+  description: 'Pulse of a grayscale electronic heart',
+  author: 'AudioVisualizer',
+  version: '1.0.0',
+  category: 'one-shot',
+  tags: ['heart', 'pulse', 'one-shot'],
+  thumbnail: 'heart_beat_thumb.png',
+  note: 62,
+  defaultConfig: {
+    opacity: 1.0,
+    duration: 1.5,
+    color: '#ffffff',
+    scale: 1.0
+  },
+  controls: [
+    { name: 'color', type: 'color', label: 'Color', default: '#ffffff' },
+    { name: 'duration', type: 'slider', label: 'Duration', min: 0.5, max: 3, step: 0.1, default: 1.5 },
+    { name: 'scale', type: 'slider', label: 'Scale', min: 0.5, max: 2, step: 0.1, default: 1.0 }
+  ],
+  audioMapping: {
+    low: { description: 'Triggers heart beat', frequency: '20-250 Hz', effect: 'Pulse amplitude' },
+    mid: { description: 'Modulates glow', frequency: '250-4000 Hz', effect: 'Glow intensity' },
+    high: { description: 'Adds shimmer', frequency: '4000+ Hz', effect: 'Subtle flicker' }
+  },
+  performance: { complexity: 'low', recommendedFPS: 60, gpuIntensive: false }
+};
+
+class HeartBeatPreset extends BasePreset {
+  private mesh!: THREE.Mesh<THREE.ShapeGeometry, THREE.MeshBasicMaterial>;
+  private startTime = 0;
+  private currentConfig: any;
+
+  constructor(scene: THREE.Scene, camera: THREE.Camera, renderer: THREE.WebGLRenderer, cfg: PresetConfig) {
+    super(scene, camera, renderer, cfg);
+  }
+
+  public init(): void {
+    this.renderer.setClearColor(0x000000, 0);
+    this.currentConfig = JSON.parse(JSON.stringify(this.config.defaultConfig));
+
+    const heartShape = new THREE.Shape();
+    heartShape.moveTo(0, 0);
+    heartShape.bezierCurveTo(0, 0, -0.5, -0.3, -1, 0);
+    heartShape.bezierCurveTo(-2, 1.5, -1.5, 3, 0, 3.5);
+    heartShape.bezierCurveTo(1.5, 3, 2, 1.5, 1, 0);
+    heartShape.bezierCurveTo(0.5, -0.3, 0, 0, 0, 0);
+
+    const geometry = new THREE.ShapeGeometry(heartShape);
+    const material = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(this.currentConfig.color),
+      transparent: true
+    });
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.mesh.rotation.z = Math.PI; // orient heart upright
+    this.mesh.scale.setScalar(this.currentConfig.scale);
+    this.scene.add(this.mesh);
+
+    this.startTime = this.clock.getElapsedTime();
+  }
+
+  public update(): void {
+    const t = this.clock.getElapsedTime() - this.startTime;
+    const progress = t / this.currentConfig.duration;
+    if (progress > 1) {
+      this.dispose();
+      return;
+    }
+
+    const beat = Math.abs(Math.sin(progress * Math.PI * 2));
+    const scale = this.currentConfig.scale * (0.8 + beat * 0.4 + this.audioData.low * 0.1);
+    this.mesh.scale.setScalar(scale);
+
+    const material = this.mesh.material as THREE.MeshBasicMaterial;
+    const grey = 1 - this.audioData.mid * 0.3;
+    material.color.setScalar(grey);
+    material.opacity = 1 - progress;
+  }
+
+  public updateConfig(newConfig: any): void {
+    this.currentConfig = { ...this.currentConfig, ...newConfig };
+    if (newConfig.color) {
+      (this.mesh.material as THREE.MeshBasicMaterial).color.set(newConfig.color);
+    }
+    if (newConfig.scale) {
+      this.mesh.scale.setScalar(newConfig.scale);
+    }
+  }
+
+  public dispose(): void {
+    this.scene.remove(this.mesh);
+    this.mesh.geometry.dispose();
+    this.mesh.material.dispose();
+  }
+}
+
+export function createPreset(
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  renderer: THREE.WebGLRenderer,
+  cfg: PresetConfig,
+  shaderCode?: string
+): BasePreset {
+  return new HeartBeatPreset(scene, camera, renderer, cfg);
+}

--- a/src/presets/soft-flare/config.json
+++ b/src/presets/soft-flare/config.json
@@ -1,0 +1,29 @@
+{
+  "name": "Soft Flare",
+  "description": "Gentle fullscreen flare that fades quickly",
+  "author": "AudioVisualizer",
+  "version": "1.0.0",
+  "category": "one-shot",
+  "tags": ["flare", "flash", "one-shot"],
+  "thumbnail": "soft_flare_thumb.png",
+  "note": 63,
+  "defaultConfig": {
+    "opacity": 1.0,
+    "duration": 1.0,
+    "color": "#e0f7ff"
+  },
+  "controls": [
+    {"name": "color", "type": "color", "label": "Color", "default": "#e0f7ff"},
+    {"name": "duration", "type": "slider", "label": "Duration", "min": 0.5, "max": 2, "step": 0.1, "default": 1.0}
+  ],
+  "audioMapping": {
+    "low": {"description": "Controls brightness", "frequency": "20-250 Hz", "effect": "Intensity"},
+    "mid": {"description": "Modulates radius", "frequency": "250-4000 Hz", "effect": "Radius"},
+    "high": {"description": "Adds sparkle", "frequency": "4000+ Hz", "effect": "Sparkle"}
+  },
+  "performance": {
+    "complexity": "low",
+    "recommendedFPS": 60,
+    "gpuIntensive": false
+  }
+}

--- a/src/presets/soft-flare/preset.ts
+++ b/src/presets/soft-flare/preset.ts
@@ -1,0 +1,105 @@
+import * as THREE from 'three';
+import { BasePreset, PresetConfig } from '../../core/PresetLoader';
+
+export const config: PresetConfig = {
+  name: 'Soft Flare',
+  description: 'Gentle fullscreen flare that fades quickly',
+  author: 'AudioVisualizer',
+  version: '1.0.0',
+  category: 'one-shot',
+  tags: ['flare', 'flash', 'one-shot'],
+  thumbnail: 'soft_flare_thumb.png',
+  note: 63,
+  defaultConfig: {
+    opacity: 1.0,
+    duration: 1.0,
+    color: '#e0f7ff'
+  },
+  controls: [
+    { name: 'color', type: 'color', label: 'Color', default: '#e0f7ff' },
+    { name: 'duration', type: 'slider', label: 'Duration', min: 0.5, max: 2, step: 0.1, default: 1.0 }
+  ],
+  audioMapping: {
+    low: { description: 'Controls brightness', frequency: '20-250 Hz', effect: 'Intensity' },
+    mid: { description: 'Modulates radius', frequency: '250-4000 Hz', effect: 'Radius' },
+    high: { description: 'Adds sparkle', frequency: '4000+ Hz', effect: 'Sparkle' }
+  },
+  performance: { complexity: 'low', recommendedFPS: 60, gpuIntensive: false }
+};
+
+class SoftFlarePreset extends BasePreset {
+  private mesh!: THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>;
+  private start = 0;
+  private currentConfig: any;
+
+  constructor(scene: THREE.Scene, camera: THREE.Camera, renderer: THREE.WebGLRenderer, cfg: PresetConfig) {
+    super(scene, camera, renderer, cfg);
+  }
+
+  public init(): void {
+    this.renderer.setClearColor(0x000000, 0);
+    this.currentConfig = JSON.parse(JSON.stringify(this.config.defaultConfig));
+
+    const geometry = new THREE.PlaneGeometry(10, 10);
+    const material = new THREE.ShaderMaterial({
+      transparent: true,
+      uniforms: {
+        uColor: { value: new THREE.Color(this.currentConfig.color) },
+        uProgress: { value: 0 }
+      },
+      vertexShader: `
+        varying vec2 vUv;
+        void main(){
+          vUv = uv;
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+        }
+      `,
+      fragmentShader: `
+        varying vec2 vUv;
+        uniform vec3 uColor;
+        uniform float uProgress;
+        void main(){
+          float dist = length(vUv - vec2(0.5));
+          float alpha = smoothstep(0.5, 0.0, dist) * (1.0 - uProgress);
+          gl_FragColor = vec4(uColor, alpha);
+        }
+      `
+    });
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.scene.add(this.mesh);
+    this.start = this.clock.getElapsedTime();
+  }
+
+  public update(): void {
+    const t = this.clock.getElapsedTime();
+    const progress = (t - this.start) / this.currentConfig.duration;
+    const mat = this.mesh.material as THREE.ShaderMaterial;
+    mat.uniforms.uProgress.value = progress;
+    if (progress > 1) {
+      this.dispose();
+    }
+  }
+
+  public updateConfig(newConfig: any): void {
+    this.currentConfig = { ...this.currentConfig, ...newConfig };
+    if (newConfig.color) {
+      (this.mesh.material as THREE.ShaderMaterial).uniforms.uColor.value = new THREE.Color(newConfig.color);
+    }
+  }
+
+  public dispose(): void {
+    this.scene.remove(this.mesh);
+    this.mesh.geometry.dispose();
+    this.mesh.material.dispose();
+  }
+}
+
+export function createPreset(
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  renderer: THREE.WebGLRenderer,
+  cfg: PresetConfig,
+  shaderCode?: string
+): BasePreset {
+  return new SoftFlarePreset(scene, camera, renderer, cfg);
+}


### PR DESCRIPTION
## Summary
- ensure MIDI notes are unique across presets
- add Heart Beat one-shot visual preset
- add Soft Flare full-screen flash preset

## Testing
- `node <<'NODE'
const fs=require('fs');
const notes={};
let dup=false;
for(const p of fs.readdirSync('src/presets')){
  const file=`src/presets/${p}/config.json`;
  if(fs.existsSync(file)){
    const note=JSON.parse(fs.readFileSync(file,'utf-8')).note;
    if(notes[note]){
      console.log('Duplicate note',note,'in',p,'and',notes[note]);
      dup=true;
    } else {
      notes[note]=p;
    }
  }
}
if(!dup) console.log('All notes unique');
NODE`
- `npm test`
- `npm run build` *(fails: Error failed to get cargo metadata: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a63cfa3f288333842d0787737fc1c4