### PR TITLE
Fix fullscreen visual output across monitors

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -41,16 +41,6 @@ fn main() {
             midi::start(app.handle().clone());
             audio::start(app.handle().clone());
             tauri::async_runtime::spawn(gpu::init());
-            let handle = app.handle();
-            let _ = tauri::WindowBuilder::new(&handle, "screen1", tauri::WindowUrl::App("index.html".into()))
-                .fullscreen(true)
-                .build();
-            let _ = tauri::WindowBuilder::new(&handle, "screen2", tauri::WindowUrl::App("index.html".into()))
-                .fullscreen(true)
-                .build();
-            let _ = tauri::WindowBuilder::new(&handle, "screen3", tauri::WindowUrl::App("index.html".into()))
-                .fullscreen(true)
-                .build();
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
## Summary
- Track fullscreen mode in React to hide UI and exit with ESC
- Remove startup fullscreen windows so only selected monitors open visuals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a63eee9020833396b2840788f07da8