### PR TITLE
fix: guard fs access and handle fullscreen resize

### DIFF
--- a/src/core/PresetLoader.ts
+++ b/src/core/PresetLoader.ts
@@ -234,7 +234,12 @@ export interface LoadedPreset {
   private async persistNote(presetId: string, note: number): Promise<void> {
     try {
       const path = `src/presets/${presetId}/config.json`;
-      if (fs.existsSync(path)) {
+      if (
+        typeof fs?.existsSync === 'function' &&
+        typeof fs?.readFileSync === 'function' &&
+        typeof fs?.writeFileSync === 'function' &&
+        fs.existsSync(path)
+      ) {
         const json = JSON.parse(fs.readFileSync(path, 'utf-8'));
         json.note = note;
         fs.writeFileSync(path, JSON.stringify(json, null, 2));


### PR DESCRIPTION
## Summary
- avoid calling Node fs APIs when running without filesystem
- prevent zero-size render targets on fullscreen resize

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Unable to find your web assets, did you forget to build your web app?)*

------
https://chatgpt.com/codex/tasks/task_e_68a64069c8688333b9f704190c6bf555