### PR TITLE
feat: add configurable UI hide hotkey

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,12 +21,19 @@ body {
   grid-template-rows: 40px 300px 1fr;
 }
 
-.app.fullscreen-mode {
+.app.ui-hidden {
   display: flex;
   grid-template-rows: none;
 }
 
-.app.fullscreen-mode .main-canvas {
+.app.ui-hidden .top-bar,
+.app.ui-hidden .layer-grid-container,
+.app.ui-hidden .controls-panel,
+.app.ui-hidden .status-bar {
+  display: none;
+}
+
+.app.ui-hidden .main-canvas {
   border: none;
 }
 

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -39,6 +39,8 @@ interface GlobalSettingsModalProps {
   onToggleMonitor: (id: string) => void;
   glitchTextPads: number;
   onGlitchPadChange: (value: number) => void;
+  hideUiHotkey: string;
+  onHideUiHotkeyChange: (value: string) => void;
 }
 
 export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
@@ -62,7 +64,9 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   selectedMonitors,
   onToggleMonitor,
   glitchTextPads,
-  onGlitchPadChange
+  onGlitchPadChange,
+  hideUiHotkey,
+  onHideUiHotkeyChange
 }) => {
   const [activeTab, setActiveTab] = useState('audio');
   
@@ -491,7 +495,23 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
           {activeTab === 'visual' && (
             <div className="settings-section">
               <h3>🎨 Configuración Visual</h3>
-              
+              <div className="setting-group">
+                <label className="setting-label">
+                  <span>Tecla para ocultar UI</span>
+                  <input
+                    type="text"
+                    value={hideUiHotkey}
+                    onKeyDown={(e) => {
+                      e.preventDefault();
+                      onHideUiHotkeyChange(e.key);
+                    }}
+                    className="setting-number"
+                    readOnly
+                  />
+                </label>
+                <small className="setting-hint">Presiona una tecla (por defecto F10)</small>
+              </div>
+
               <div className="setting-group">
                 <label className="setting-label">
                   <span>Pads de Texto Glitch: {glitchTextPads}</span>


### PR DESCRIPTION
## Summary
- add F10-configurable hotkey to toggle all UI elements while visuals keep running
- expose hotkey setting in Global Settings
- replace fullscreen auto-hide logic with CSS-based `ui-hidden`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
- `npm run build` *(fails: Unable to find web assets, distDir set to "../dist")*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a642ac37a883338f6f141fdd3ef9c5