### PR TITLE
feat: mirror fullscreen on selected monitors

### DIFF
--- a/preload.cjs
+++ b/preload.cjs
@@ -2,5 +2,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   applySettings: (settings) => ipcRenderer.send('apply-settings', settings),
-  getDisplays: () => ipcRenderer.invoke('get-displays')
+  getDisplays: () => ipcRenderer.invoke('get-displays'),
+  toggleFullscreen: (ids) => ipcRenderer.invoke('toggle-fullscreen', ids)
 });

--- a/types/globa.d.ts
+++ b/types/globa.d.ts
@@ -4,6 +4,7 @@ interface Window {
   electronAPI?: {
     applySettings: (settings: { maximize?: boolean; monitorId?: number }) => void;
     getDisplays: () => Promise<{ id: number; label: string; bounds: { x: number; y: number; width: number; height: number }; scaleFactor: number; primary: boolean; }[]>;
+    toggleFullscreen: (ids: number[]) => Promise<void>;
   };
 }
 


### PR DESCRIPTION
## Summary
- allow the renderer to request fullscreen windows on multiple displays via Electron
- expose `toggleFullscreen` bridge and types
- register F9 hotkey to trigger multi-monitor fullscreen

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'vite/client')*


------
https://chatgpt.com/codex/tasks/task_e_68a6c6cc00ec8333a3bb15420ddb181d