### PR TITLE
feat: sync fullscreen frames across displays

### DIFF
--- a/clone.html
+++ b/clone.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Visual Clone</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      background: #000;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+    canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="clone-canvas"></canvas>
+  <script>
+    const canvas = document.getElementById('clone-canvas');
+    const ctx = canvas.getContext('2d');
+
+    function resize() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    const api = window.electronAPI;
+    if (api && api.onReceiveFrame) {
+      api.onReceiveFrame((_event, frame) => {
+        const blob = new Blob([frame], { type: 'image/jpeg' });
+        const url = URL.createObjectURL(blob);
+        const img = new Image();
+        img.onload = () => {
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+          URL.revokeObjectURL(url);
+        };
+        img.src = url;
+      });
+    }
+
+    window.addEventListener('beforeunload', () => {
+      if (api && api.removeFrameListener) {
+        api.removeFrameListener();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/preload.cjs
+++ b/preload.cjs
@@ -3,5 +3,12 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   applySettings: (settings) => ipcRenderer.send('apply-settings', settings),
   getDisplays: () => ipcRenderer.invoke('get-displays'),
-  toggleFullscreen: (ids) => ipcRenderer.invoke('toggle-fullscreen', ids)
+  toggleFullscreen: (ids) => ipcRenderer.invoke('toggle-fullscreen', ids),
+
+  // Envío de frames desde la ventana principal
+  broadcastFrame: (frameData) => ipcRenderer.send('broadcast-frame', frameData),
+
+  // Recepción de frames en ventanas clon
+  onReceiveFrame: (callback) => ipcRenderer.on('receive-frame', callback),
+  removeFrameListener: () => ipcRenderer.removeAllListeners('receive-frame')
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -529,9 +529,16 @@ const App: React.FC = () => {
         setStatus('Error: No hay monitores seleccionados');
         return;
       }
+      // Activar o desactivar modo multi-monitor según corresponda
+      if (isFullscreenMode) {
+        engineRef.current?.setMultiMonitorMode(false);
+      } else {
+        engineRef.current?.setMultiMonitorMode(ids.length > 1);
+      }
       try {
         await (window as any).electronAPI.toggleFullscreen(ids);
         setStatus(`Fullscreen toggled en ${ids.length} monitor(es)`);
+        setIsFullscreenMode(!isFullscreenMode);
       } catch (err) {
         console.error('Error en fullscreen:', err);
         setStatus('Error: No se pudo activar fullscreen');
@@ -549,6 +556,12 @@ const App: React.FC = () => {
         if (selectedMonitorsList.length === 0) {
           setStatus('Error: No hay monitores seleccionados');
           return;
+        }
+        // Activar o desactivar modo multi-monitor según corresponda
+        if (isFullscreenMode) {
+          engineRef.current?.setMultiMonitorMode(false);
+        } else {
+          engineRef.current?.setMultiMonitorMode(selectedMonitorsList.length > 1);
         }
 
         console.log(`🎯 Abriendo fullscreen en ${selectedMonitorsList.length} monitores`);
@@ -581,6 +594,7 @@ const App: React.FC = () => {
         });
 
         setStatus(`Fullscreen activo en ${selectedMonitorsList.length} monitor(es)`);
+        setIsFullscreenMode(!isFullscreenMode);
       } catch (err) {
         console.error('Error en fullscreen:', err);
         setStatus('Error: No se pudo activar fullscreen');

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -26,6 +26,8 @@ export class AudioVisualizerEngine {
   private presetLoader: PresetLoader;
   private animationId: number | null = null;
   private isRunning = false;
+  private multiMonitorMode = false;
+  private lastFrameSent = 0;
 
   // Compositing scene para mezclar layers
   private compositingScene: THREE.Scene;
@@ -277,6 +279,25 @@ export class AudioVisualizerEngine {
 
     // Renderizar composición final con blending correcto
     this.renderer.render(this.compositingScene, this.compositingCamera);
+
+    // Si estamos en modo multi-monitor, enviar frames a las ventanas clon
+    if (this.multiMonitorMode && typeof window !== 'undefined') {
+      const api = (window as any).electronAPI;
+      const now = performance.now();
+      // Throttle a ~30 FPS (33ms)
+      if (api?.broadcastFrame && now - this.lastFrameSent > 33) {
+        this.lastFrameSent = now;
+        this.canvas.toBlob(async (blob) => {
+          if (!blob) return;
+          const buffer = await blob.arrayBuffer();
+          api.broadcastFrame(Buffer.from(buffer));
+        }, 'image/jpeg', 0.7);
+      }
+    }
+  }
+
+  public setMultiMonitorMode(active: boolean): void {
+    this.multiMonitorMode = active;
   }
 
   public async activateLayerPreset(layerId: string, presetId: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- add dedicated `clone.html` page for secondary monitors
- broadcast rendered frames via IPC and display on clone windows
- toggle fullscreen now uses main window for rendering and streams frames at ~30 FPS when in multi-monitor mode

## Testing
- `npm run build` *(fails: Unable to find your web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a7326452bc8333804c67b4db31a28c