### PR TITLE
feat: mirror main window on secondary screens

### DIFF
--- a/preload.cjs
+++ b/preload.cjs
@@ -4,10 +4,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   applySettings: (settings) => ipcRenderer.send('apply-settings', settings),
   getDisplays: () => ipcRenderer.invoke('get-displays'),
   toggleFullscreen: (ids) => ipcRenderer.invoke('toggle-fullscreen', ids),
-
-  // Envío de frames desde la ventana principal
-  broadcastFrame: (frameData) => ipcRenderer.send('broadcast-frame', frameData),
-
   // Recepción de frames en ventanas clon
   onReceiveFrame: (callback) => ipcRenderer.on('receive-frame', callback),
   removeFrameListener: () => ipcRenderer.removeAllListeners('receive-frame'),

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -27,7 +27,6 @@ export class AudioVisualizerEngine {
   private animationId: number | null = null;
   private isRunning = false;
   private multiMonitorMode = false;
-  private lastFrameSent = 0;
 
   // Compositing scene para mezclar layers
   private compositingScene: THREE.Scene;
@@ -283,21 +282,6 @@ export class AudioVisualizerEngine {
 
     // Renderizar composición final con blending correcto
     this.renderer.render(this.compositingScene, this.compositingCamera);
-
-    // Si estamos en modo multi-monitor, enviar frames a las ventanas clon
-    if (this.multiMonitorMode && typeof window !== 'undefined') {
-      const api = (window as any).electronAPI;
-      const now = performance.now();
-      // Throttle a ~30 FPS (33ms)
-      if (api?.broadcastFrame && now - this.lastFrameSent > 33) {
-        this.lastFrameSent = now;
-        this.canvas.toBlob(async (blob) => {
-          if (!blob) return;
-          const buffer = await blob.arrayBuffer();
-          api.broadcastFrame(Buffer.from(buffer));
-        }, 'image/jpeg', 0.7);
-      }
-    }
   }
 
   public setMultiMonitorMode(active: boolean): void {


### PR DESCRIPTION
## Summary
- mirror main screen to secondary fullscreen windows using capturePage
- drop frame broadcast from renderer to avoid stalls

## Testing
- `npm run build` *(fails: Unable to find your web assets, did you forget to build your web app?)*


------
https://chatgpt.com/codex/tasks/task_e_68a73d3c7c9083339e5f52428a540ad8