### PR TITLE
Replace butterflies with smooth pastel particles

### DIFF
--- a/src/presets/analysis/config.json
+++ b/src/presets/analysis/config.json
@@ -1,15 +1,15 @@
 {
   "name": "ANALYSIS",
-  "description": "3D audio spectrum with low, mid, high bands, butterflies and rotating camera.",
+  "description": "3D audio spectrum with pastel particles per band and rotating camera.",
   "author": "AudioVisualizer",
   "version": "1.0.0",
   "category": "analysis",
-  "tags": ["spectrum", "analysis", "butterfly", "grid"],
+  "tags": ["spectrum", "analysis", "particles", "grid"],
   "thumbnail": "analysis_thumb.png",
   "note": 48,
   "defaultConfig": {
     "radius": 8,
-    "butterflyCount": 40,
+    "particleCount": 40,
     "colors": {
       "band1": "#A8A8A8",
       "band2": "#B58E7E",
@@ -21,7 +21,7 @@
   },
   "controls": [
     {"name": "radius", "type": "slider", "label": "Camera Radius", "min": 5, "max": 15, "step": 0.5, "default": 8},
-    {"name": "butterflyCount", "type": "slider", "label": "Max Butterflies", "min": 5, "max": 100, "step": 1, "default": 40},
+      {"name": "particleCount", "type": "slider", "label": "Max Particles", "min": 5, "max": 100, "step": 1, "default": 40},
     {"name": "colors.band1", "type": "color", "label": "Band 1 Color", "default": "#A8A8A8"},
     {"name": "colors.band2", "type": "color", "label": "Band 2 Color", "default": "#B58E7E"},
     {"name": "colors.band3", "type": "color", "label": "Band 3 Color", "default": "#D97E7E"},
@@ -30,12 +30,12 @@
     {"name": "colors.band6", "type": "color", "label": "Band 6 Color", "default": "#E68A7A"}
   ],
   "audioMapping": {
-    "band1": {"description": "Very low frequencies", "frequency": "40-200 Hz", "effect": "Butterfly density band 1"},
-    "band2": {"description": "Low frequencies", "frequency": "200-400 Hz", "effect": "Butterfly density band 2"},
-    "band3": {"description": "Low mid frequencies", "frequency": "400-600 Hz", "effect": "Butterfly density band 3"},
-    "band4": {"description": "Mid frequencies", "frequency": "600-1000 Hz", "effect": "Butterfly density band 4"},
-    "band5": {"description": "High mid frequencies", "frequency": "1000-10000 Hz", "effect": "Butterfly density band 5"},
-    "band6": {"description": "High frequencies", "frequency": "10000-22000 Hz", "effect": "Butterfly density band 6"}
+      "band1": {"description": "Very low frequencies", "frequency": "40-200 Hz", "effect": "Particle density band 1"},
+      "band2": {"description": "Low frequencies", "frequency": "200-400 Hz", "effect": "Particle density band 2"},
+      "band3": {"description": "Low mid frequencies", "frequency": "400-600 Hz", "effect": "Particle density band 3"},
+      "band4": {"description": "Mid frequencies", "frequency": "600-1000 Hz", "effect": "Particle density band 4"},
+      "band5": {"description": "High mid frequencies", "frequency": "1000-10000 Hz", "effect": "Particle density band 5"},
+      "band6": {"description": "High frequencies", "frequency": "10000-22000 Hz", "effect": "Particle density band 6"}
   },
   "performance": {"complexity": "low", "recommendedFPS": 60, "gpuIntensive": false}
 }

--- a/src/presets/analysis/preset.ts
+++ b/src/presets/analysis/preset.ts
@@ -3,28 +3,28 @@ import { BasePreset, PresetConfig } from '../../core/PresetLoader';
 
 export const config: PresetConfig = {
   name: 'ANALYSIS',
-  description: '3D audio spectrum analyzer with smooth butterfly transitions and frequency/dB grid.',
+  description: '3D audio spectrum analyzer with smooth pastel particle transitions and frequency/dB grid.',
   author: 'AudioVisualizer',
-  version: '2.0.0',
+  version: '2.1.0',
   category: 'analysis',
-  tags: ['spectrum', 'analysis', 'butterfly', 'grid', 'nature'],
+  tags: ['spectrum', 'analysis', 'particles', 'grid', 'nature'],
   thumbnail: 'analysis_thumb.png',
   note: 48,
   defaultConfig: {
     radius: 8,
-    butterflyCount: 60,
-      colors: {
-        band1: '#A8A8A8',  // 40-200Hz - Gris pastel
-        band2: '#B58E7E',  // 200-400Hz - Marrón suave
-        band3: '#D97E7E',  // 400-600Hz - Rojo pastel
-        band4: '#8B6F6F',  // 600-1000Hz - Marrón violeta oscuro
-        band5: '#C49A9A',  // 1000-10000Hz - Rosa grisáceo
-        band6: '#E68A7A'   // 10000-22000Hz - Coral pastel
-      }
-    },
+    particleCount: 60,
+    colors: {
+      band1: '#A8A8A8',
+      band2: '#B58E7E',
+      band3: '#D97E7E',
+      band4: '#8B6F6F',
+      band5: '#C49A9A',
+      band6: '#E68A7A'
+    }
+  },
   controls: [
     { name: 'radius', type: 'slider', label: 'Camera Radius', min: 5, max: 15, step: 0.5, default: 8 },
-    { name: 'butterflyCount', type: 'slider', label: 'Max Butterflies', min: 20, max: 120, step: 5, default: 60 },
+    { name: 'particleCount', type: 'slider', label: 'Max Particles', min: 20, max: 120, step: 5, default: 60 },
     { name: 'colors.band1', type: 'color', label: '40-200Hz Color', default: '#A8A8A8' },
     { name: 'colors.band2', type: 'color', label: '200-400Hz Color', default: '#B58E7E' },
     { name: 'colors.band3', type: 'color', label: '400-600Hz Color', default: '#D97E7E' },
@@ -33,20 +33,18 @@ export const config: PresetConfig = {
     { name: 'colors.band6', type: 'color', label: '10-22kHz Color', default: '#E68A7A' }
   ],
   audioMapping: {
-    band1: { description: 'Sub-bass frequencies', frequency: '40-200 Hz', effect: 'Butterfly density and movement in zone 1' },
-    band2: { description: 'Bass frequencies', frequency: '200-400 Hz', effect: 'Butterfly density and movement in zone 2' },
-    band3: { description: 'Low mid frequencies', frequency: '400-600 Hz', effect: 'Butterfly density and movement in zone 3' },
-    band4: { description: 'Mid frequencies', frequency: '600-1000 Hz', effect: 'Butterfly density and movement in zone 4' },
-    band5: { description: 'High mid frequencies', frequency: '1000-10000 Hz', effect: 'Butterfly density and movement in zone 5' },
-    band6: { description: 'High frequencies', frequency: '10000-22000 Hz', effect: 'Butterfly density and movement in zone 6' }
+    band1: { description: 'Sub-bass frequencies', frequency: '40-200 Hz', effect: 'Particle density and movement in zone 1' },
+    band2: { description: 'Bass frequencies', frequency: '200-400 Hz', effect: 'Particle density and movement in zone 2' },
+    band3: { description: 'Low mid frequencies', frequency: '400-600 Hz', effect: 'Particle density and movement in zone 3' },
+    band4: { description: 'Mid frequencies', frequency: '600-1000 Hz', effect: 'Particle density and movement in zone 4' },
+    band5: { description: 'High mid frequencies', frequency: '1000-10000 Hz', effect: 'Particle density and movement in zone 5' },
+    band6: { description: 'High frequencies', frequency: '10000-22000 Hz', effect: 'Particle density and movement in zone 6' }
   },
   performance: { complexity: 'medium', recommendedFPS: 60, gpuIntensive: false }
 };
 
-interface Butterfly {
-  group: THREE.Group;
-  wings: { left: THREE.Mesh; right: THREE.Mesh; };
-  body: THREE.Mesh;
+interface Particle {
+  mesh: THREE.Mesh;
   speed: number;
   radius: number;
   offset: number;
@@ -54,12 +52,11 @@ interface Butterfly {
   life: number;
   deathTimer: number;
   birthTimer: number;
-  petals?: THREE.Group;
   basePosition: THREE.Vector3;
 }
 
-interface ButterflyRange {
-  butterflies: Butterfly[];
+interface ParticleRange {
+  particles: Particle[];
   color: string;
   centerX: number;
   targetCount: number;
@@ -72,7 +69,7 @@ type BandName = 'band1' | 'band2' | 'band3' | 'band4' | 'band5' | 'band6';
 
 class AnalysisSpectrum extends BasePreset {
   private group!: THREE.Group;
-  private butterflyGroups!: Record<BandName, ButterflyRange>;
+  private particleGroups!: Record<BandName, ParticleRange>;
   private gridFloor?: THREE.GridHelper;
   private gridBack?: THREE.GridHelper;
   private frequencyLabels?: THREE.Group;
@@ -82,13 +79,12 @@ class AnalysisSpectrum extends BasePreset {
   private currentConfig: any;
   private initialCameraPosition = this.camera.position.clone();
   private initialCameraQuaternion = this.camera.quaternion.clone();
-  
-  private wingGeometry!: THREE.CircleGeometry;
-  private bodyGeometry!: THREE.CapsuleGeometry;
-  private petalGeometry!: THREE.PlaneGeometry;
-  
+
+  private particleGeometry!: THREE.SphereGeometry;
+
   private smoothingFactor = 0.85;
-  private lastTime = 0;
+  private readonly BIRTH_DURATION = 0.1;
+  private readonly DEATH_DURATION = 0.5;
 
   constructor(scene: THREE.Scene, camera: THREE.Camera, renderer: THREE.WebGLRenderer, cfg: PresetConfig) {
     super(scene, camera, renderer, cfg);
@@ -99,9 +95,7 @@ class AnalysisSpectrum extends BasePreset {
     this.group = new THREE.Group();
     this.scene.add(this.group);
 
-    this.wingGeometry = new THREE.CircleGeometry(0.08, 8);
-    this.bodyGeometry = new THREE.CapsuleGeometry(0.008, 0.06, 4, 8);
-    this.petalGeometry = new THREE.PlaneGeometry(0.02, 0.03);
+    this.particleGeometry = new THREE.SphereGeometry(0.05, 16, 16);
 
     this.createFrequencyGrid();
     this.createDbGrid();
@@ -112,39 +106,31 @@ class AnalysisSpectrum extends BasePreset {
     this.pointLight = new THREE.PointLight(0xffffff, 1.5);
     this.pointLight.position.set(0, 8, 2);
     this.pointLight.castShadow = true;
-    
+
     const colorLight = new THREE.PointLight(0x4444ff, 0.8);
     colorLight.position.set(-4, 4, -2);
-    
+
     this.scene.add(this.ambient);
     this.scene.add(this.pointLight);
     this.scene.add(colorLight);
 
-    const colors = this.currentConfig.colors;
-    const bandCenters = [-3.0, -1.8, -0.6, 0.6, 1.8, 3.0];
-    
-    this.butterflyGroups = {
-      band1: { butterflies: [], color: colors.band1, centerX: bandCenters[0], targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 },
-      band2: { butterflies: [], color: colors.band2, centerX: bandCenters[1], targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 },
-      band3: { butterflies: [], color: colors.band3, centerX: bandCenters[2], targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 },
-      band4: { butterflies: [], color: colors.band4, centerX: bandCenters[3], targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 },
-      band5: { butterflies: [], color: colors.band5, centerX: bandCenters[4], targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 },
-      band6: { butterflies: [], color: colors.band6, centerX: bandCenters[5], targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 }
+    this.particleGroups = {
+      band1: { particles: [], color: this.currentConfig.colors.band1, centerX: -3.2, targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 },
+      band2: { particles: [], color: this.currentConfig.colors.band2, centerX: -1.92, targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 },
+      band3: { particles: [], color: this.currentConfig.colors.band3, centerX: -0.64, targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 },
+      band4: { particles: [], color: this.currentConfig.colors.band4, centerX: 0.64, targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 },
+      band5: { particles: [], color: this.currentConfig.colors.band5, centerX: 1.92, targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 },
+      band6: { particles: [], color: this.currentConfig.colors.band6, centerX: 3.2, targetCount: 0, currentCount: 0, audioLevel: 0, smoothedLevel: 0 }
     };
-
-    Object.values(this.butterflyGroups).forEach(range => {
-      for (let i = 0; i < 2; i++) {
-        range.butterflies.push(this.createButterfly(range.color, range.centerX));
-        range.currentCount++;
-      }
-    });
   }
 
   private createFrequencyGrid(): void {
     this.gridFloor = new THREE.GridHelper(12, 24, 0x555555, 0x222222);
     this.gridFloor.material.opacity = 0.6;
     this.gridFloor.material.transparent = true;
+    // @ts-ignore emissive exists at runtime
     this.gridFloor.material.emissive = new THREE.Color(0x111111);
+    // @ts-ignore emissiveIntensity exists at runtime
     this.gridFloor.material.emissiveIntensity = 0.25;
     this.scene.add(this.gridFloor);
   }
@@ -155,7 +141,9 @@ class AnalysisSpectrum extends BasePreset {
     this.gridBack.position.set(0, 2, -6);
     this.gridBack.material.opacity = 0.5;
     this.gridBack.material.transparent = true;
+    // @ts-ignore emissive exists at runtime
     this.gridBack.material.emissive = new THREE.Color(0x221111);
+    // @ts-ignore emissiveIntensity exists at runtime
     this.gridBack.material.emissiveIntensity = 0.2;
     this.scene.add(this.gridBack);
   }
@@ -166,11 +154,11 @@ class AnalysisSpectrum extends BasePreset {
     const context = canvas.getContext('2d')!;
     canvas.width = 128;
     canvas.height = 32;
-    
+
     const frequencies = ['40Hz', '200Hz', '400Hz', '600Hz', '1kHz', '10kHz', '22kHz'];
     const colors = ['#A8A8A8', '#B58E7E', '#D97E7E', '#8B6F6F', '#C49A9A', '#E68A7A', '#B5A5A5'];
     const positions = [-3.6, -2.4, -1.2, 0, 1.2, 2.4, 3.6];
-    
+
     frequencies.forEach((freq, i) => {
       context.clearRect(0, 0, 128, 32);
       context.shadowColor = colors[i];
@@ -179,20 +167,20 @@ class AnalysisSpectrum extends BasePreset {
       context.font = 'bold 16px Arial';
       context.textAlign = 'center';
       context.fillText(freq, 64, 20);
-      
+
       const texture = new THREE.CanvasTexture(canvas);
-      const material = new THREE.SpriteMaterial({ 
-        map: texture, 
+      const material = new THREE.SpriteMaterial({
+        map: texture,
         transparent: true,
         opacity: 0.9
       });
       const sprite = new THREE.Sprite(material);
       sprite.position.set(positions[i], 0.15, 3);
       sprite.scale.set(1.0, 0.25, 1);
-      
-      this.frequencyLabels.add(sprite);
+
+      this.frequencyLabels!.add(sprite);
     });
-    
+
     this.scene.add(this.frequencyLabels);
   }
 
@@ -202,10 +190,10 @@ class AnalysisSpectrum extends BasePreset {
     const context = canvas.getContext('2d')!;
     canvas.width = 64;
     canvas.height = 32;
-    
+
     const dbLevels = ['-60dB', '-40dB', '-20dB', '0dB'];
     const yPositions = [0.5, 1.5, 2.5, 3.5];
-    
+
     dbLevels.forEach((db, i) => {
       context.clearRect(0, 0, 64, 32);
       context.shadowColor = '#884C3A';
@@ -214,215 +202,104 @@ class AnalysisSpectrum extends BasePreset {
       context.font = 'bold 14px Arial';
       context.textAlign = 'center';
       context.fillText(db, 32, 20);
-      
+
       const texture = new THREE.CanvasTexture(canvas);
-      const material = new THREE.SpriteMaterial({ 
-        map: texture, 
+      const material = new THREE.SpriteMaterial({
+        map: texture,
         transparent: true,
         opacity: 0.9
       });
       const sprite = new THREE.Sprite(material);
       sprite.position.set(-4.5, yPositions[i], -5.8);
       sprite.scale.set(0.8, 0.2, 1);
-      
-      this.dbLabels.add(sprite);
+
+      this.dbLabels!.add(sprite);
     });
-    
+
     this.scene.add(this.dbLabels);
   }
 
-  private createButterfly(colorHex: string, centerX: number): Butterfly {
-    const group = new THREE.Group();
+  private createParticle(colorHex: string, centerX: number): Particle {
     const color = new THREE.Color(colorHex);
-    
-    const wingMaterial = new THREE.MeshLambertMaterial({ 
-      color: color,
-      side: THREE.DoubleSide,
-      transparent: true,
-      opacity: 0.9,
+    const material = new THREE.MeshLambertMaterial({
+      color,
       emissive: color.clone().multiplyScalar(0.3),
-      emissiveIntensity: 0.4
+      emissiveIntensity: 0.4,
+      transparent: true,
+      opacity: 0
     });
-    
-    const leftWing = new THREE.Mesh(this.wingGeometry, wingMaterial.clone());
-    const rightWing = new THREE.Mesh(this.wingGeometry, wingMaterial.clone());
-    
-    leftWing.position.set(-0.06, 0, 0);
-    rightWing.position.set(0.06, 0, 0);
-    
-    const bodyMaterial = new THREE.MeshLambertMaterial({ 
-      color: 0xffffff,
-      emissive: color.clone().multiplyScalar(0.2),
-      emissiveIntensity: 0.3
-    });
-    const body = new THREE.Mesh(this.bodyGeometry, bodyMaterial);
-    body.rotation.z = Math.PI / 2;
-    
-    group.add(leftWing);
-    group.add(rightWing);
-    group.add(body);
-    
+
+    const mesh = new THREE.Mesh(this.particleGeometry, material);
+
     const baseX = centerX + (Math.random() - 0.5) * 1.2;
     const baseY = 0.5 + Math.random() * 1.5;
     const baseZ = (Math.random() - 0.5) * 2;
     const radius = 0.2 + Math.random() * 0.4;
     const speed = 0.4 + Math.random() * 0.6;
     const offset = Math.random() * Math.PI * 2;
-    const scale = 0.6 + Math.random() * 0.4;
+    const scale = 0.15 + Math.random() * 0.2;
 
-    group.scale.setScalar(scale);
-    group.position.set(baseX, baseY, baseZ);
-    
-    this.group.add(group);
-    
+    mesh.scale.setScalar(0.0001);
+    mesh.position.set(baseX, baseY, baseZ);
+
+    this.group.add(mesh);
+
     return {
-      group,
-      wings: { left: leftWing, right: rightWing },
-      body,
+      mesh,
       speed,
       radius,
       offset,
       scale,
       life: 0,
       deathTimer: 0,
-      birthTimer: 0,
+      birthTimer: this.BIRTH_DURATION,
       basePosition: new THREE.Vector3(baseX, baseY, baseZ)
     };
   }
 
-  private createDeathPetals(butterfly: Butterfly): void {
-    const petalsGroup = new THREE.Group();
-    const color = new THREE.Color((butterfly.wings.left.material as THREE.MeshLambertMaterial).color);
-    
-    const petalCount = 6 + Math.floor(Math.random() * 3);
-    
-    for (let i = 0; i < petalCount; i++) {
-      const petal = new THREE.Mesh(
-        this.petalGeometry,
-        new THREE.MeshLambertMaterial({
-          color: color.clone().multiplyScalar(1.2),
-          transparent: true,
-          opacity: 0.8,
-          emissive: color.clone().multiplyScalar(0.4),
-          emissiveIntensity: 0.5
-        })
-      );
-      
-      const angle = (i / petalCount) * Math.PI * 2;
-      petal.position.set(
-        Math.cos(angle) * 0.02,
-        Math.sin(angle) * 0.02,
-        (Math.random() - 0.5) * 0.02
-      );
-      
-      petal.rotation.z = Math.random() * Math.PI * 2;
-      petal.userData = {
-        velocity: new THREE.Vector3(
-          Math.cos(angle) * (0.2 + Math.random() * 0.15),
-          Math.random() * 0.1,
-          Math.sin(angle) * (0.2 + Math.random() * 0.15)
-        ),
-        angularVelocity: (Math.random() - 0.5) * 0.15
-      };
-      
-      petalsGroup.add(petal);
-    }
-    
-    petalsGroup.position.copy(butterfly.group.position);
-    butterfly.petals = petalsGroup;
-    this.group.add(petalsGroup);
-  }
-
-  private updatePetals(deltaTime: number): void {
-    Object.values(this.butterflyGroups).forEach(range => {
-      range.butterflies.forEach(butterfly => {
-        if (butterfly.petals) {
-          butterfly.petals.children.forEach((petal: THREE.Mesh) => {
-            const userData = petal.userData;
-            
-            petal.position.add(userData.velocity.clone().multiplyScalar(deltaTime));
-            userData.velocity.y -= 0.3 * deltaTime;
-            userData.velocity.multiplyScalar(0.98);
-            
-            petal.rotation.z += userData.angularVelocity * deltaTime;
-            
-            const material = petal.material as THREE.MeshLambertMaterial;
-            material.opacity -= deltaTime * 1.5;
-            
-            if (material.opacity <= 0) {
-              butterfly.petals!.remove(petal);
-            }
-          });
-          
-          if (butterfly.petals.children.length === 0) {
-            this.group.remove(butterfly.petals);
-            butterfly.petals = undefined;
-          }
-        }
-      });
-    });
-  }
-
-  private adjustButterflies(range: ButterflyRange, target: number, deltaTime: number): void {
+  private adjustParticles(range: ParticleRange, target: number, deltaTime: number): void {
     range.targetCount = target;
-    
+
     if (range.currentCount < target) {
-      const spawnRate = 3.0;
+      const spawnRate = 5.0;
       if (Math.random() < spawnRate * deltaTime) {
-        const newButterfly = this.createButterfly(range.color, range.centerX);
-        newButterfly.birthTimer = 0.8;
-        range.butterflies.push(newButterfly);
+        const newParticle = this.createParticle(range.color, range.centerX);
+        range.particles.push(newParticle);
         range.currentCount++;
       }
     }
-    
+
     if (range.currentCount > target) {
-      range.butterflies.forEach(butterfly => {
-        if (butterfly.life > 0.5 && butterfly.deathTimer === 0 && Math.random() < 0.5 * deltaTime) {
-          butterfly.deathTimer = 1.2;
-          butterfly.life = -1;
+      range.particles.forEach(particle => {
+        if (particle.life > 0.5 && particle.deathTimer === 0 && Math.random() < 0.5 * deltaTime) {
+          particle.deathTimer = this.DEATH_DURATION;
+          particle.life = -1;
         }
       });
     }
-    
-    for (let i = range.butterflies.length - 1; i >= 0; i--) {
-      const butterfly = range.butterflies[i];
-      
-      if (butterfly.birthTimer > 0) {
-        butterfly.birthTimer -= deltaTime * 1.5;
-        const birthProgress = 1.0 - butterfly.birthTimer;
-        butterfly.group.scale.setScalar(butterfly.scale * birthProgress);
-        butterfly.life = Math.min(1.0, birthProgress * 1.5);
-        
-        const opacity = Math.min(1.0, birthProgress * 2);
-        butterfly.wings.left.material.opacity = opacity * 0.8;
-        butterfly.wings.right.material.opacity = opacity * 0.8;
-        
-      } else if (butterfly.deathTimer > 0) {
-        butterfly.deathTimer -= deltaTime;
-        const deathProgress = 1.0 - butterfly.deathTimer;
-        
-        butterfly.speed *= (1.0 - deltaTime * 0.3);
-        
-        const scale = butterfly.scale * (1.0 - deathProgress * 0.3);
-        butterfly.group.scale.setScalar(scale);
-        
-        const opacity = (1.0 - deathProgress) * 0.8;
-        butterfly.wings.left.material.opacity = opacity;
-        butterfly.wings.right.material.opacity = opacity;
-        
-        if (deathProgress > 0.6 && !butterfly.petals) {
-          this.createDeathPetals(butterfly);
-        }
-        
-        if (butterfly.deathTimer <= 0) {
-          this.group.remove(butterfly.group);
-          range.butterflies.splice(i, 1);
+
+    for (let i = range.particles.length - 1; i >= 0; i--) {
+      const particle = range.particles[i];
+      const material = particle.mesh.material as THREE.MeshLambertMaterial;
+
+      if (particle.birthTimer > 0) {
+        particle.birthTimer -= deltaTime;
+        const progress = 1 - particle.birthTimer / this.BIRTH_DURATION;
+        particle.mesh.scale.setScalar(particle.scale * progress);
+        material.opacity = progress;
+        particle.life = progress;
+      } else if (particle.deathTimer > 0) {
+        particle.deathTimer -= deltaTime;
+        const progress = 1 - particle.deathTimer / this.DEATH_DURATION;
+        particle.mesh.scale.setScalar(particle.scale * (1 - progress));
+        material.opacity = 1 - progress;
+        if (particle.deathTimer <= 0) {
+          this.group.remove(particle.mesh);
+          range.particles.splice(i, 1);
           range.currentCount--;
         }
-        
       } else {
-        butterfly.life = Math.min(1.0, butterfly.life + deltaTime * 0.8);
+        particle.life = Math.min(1.0, particle.life + deltaTime * 0.8);
       }
     }
   }
@@ -431,7 +308,7 @@ class AnalysisSpectrum extends BasePreset {
     const time = this.clock.getElapsedTime();
     const deltaTime = this.clock.getDelta();
     const fft = this.audioData.fft;
-    
+
     const sampleRate = 44100;
     const nyquist = sampleRate / 2;
     const ranges: [number, number][] = [
@@ -442,74 +319,56 @@ class AnalysisSpectrum extends BasePreset {
       [1000, 10000],
       [10000, 22000]
     ];
-    
+
     const amps = ranges.map(([low, high]) => {
       const start = Math.floor((low / nyquist) * fft.length);
       const end = Math.floor((high / nyquist) * fft.length);
       let sum = 0;
       let count = 0;
-      
+
       for (let i = start; i < end && i < fft.length; i++) {
         sum += fft[i] * fft[i];
         count++;
       }
-      
+
       return count > 0 ? Math.sqrt(sum / count) : 0;
     });
 
     const keys: BandName[] = ['band1', 'band2', 'band3', 'band4', 'band5', 'band6'];
 
     keys.forEach((key, i) => {
-      const range = this.butterflyGroups[key];
+      const range = this.particleGroups[key];
       const rawAmp = Math.max(amps[i], 0);
-      
+
       range.audioLevel = rawAmp;
       range.smoothedLevel = range.smoothedLevel * this.smoothingFactor + rawAmp * (1 - this.smoothingFactor);
-      
+
       const sensitivity = 1.2;
-      const minButterflies = 1;
-      const maxPerBand = Math.floor(this.currentConfig.butterflyCount / 6);
-      const target = Math.max(minButterflies, 
+      const minParticles = 1;
+      const maxPerBand = Math.floor(this.currentConfig.particleCount / 6);
+      const target = Math.max(minParticles,
         Math.min(maxPerBand, Math.floor(range.smoothedLevel * sensitivity * maxPerBand))
       );
-      
-      this.adjustButterflies(range, target, deltaTime);
-      
-        range.butterflies.forEach(butterfly => {
-          if (butterfly.life > 0 && butterfly.deathTimer === 0) {
-            const flightTime = time * butterfly.speed + butterfly.offset;
 
-            const audioInfluence = range.smoothedLevel * 1.5;
-            const jitter = butterfly.radius + audioInfluence * 0.5;
-            const x = butterfly.basePosition.x + Math.sin(flightTime) * jitter;
-            const y = butterfly.basePosition.y + Math.cos(flightTime * 1.5) * jitter * 0.5 + audioInfluence * 0.3;
-            const z = butterfly.basePosition.z + Math.cos(flightTime * 0.7) * jitter;
+      this.adjustParticles(range, target, deltaTime);
 
-            butterfly.group.position.set(x, y, z);
-          
-          const baseBeat = Math.sin(time * 6 + butterfly.offset) * 0.3;
-          const audioBeat = range.audioLevel * 0.4;
-          const finalBeat = baseBeat + audioBeat;
-          
-          butterfly.wings.left.rotation.z = finalBeat;
-          butterfly.wings.right.rotation.z = -finalBeat;
-          
-          butterfly.group.rotation.y = Math.sin(flightTime * 0.5) * 0.15;
-          
-          const baseBrightness = 0.9 + range.smoothedLevel * 0.6;
+      range.particles.forEach(particle => {
+        if (particle.life > 0 && particle.deathTimer === 0) {
+          const flightTime = time * particle.speed + particle.offset;
+          const audioInfluence = range.smoothedLevel * 1.5;
+          const jitter = particle.radius + audioInfluence * 0.5;
+          const x = particle.basePosition.x + Math.sin(flightTime) * jitter;
+          const y = particle.basePosition.y + Math.cos(flightTime * 1.5) * jitter * 0.5 + audioInfluence * 0.3;
+          const z = particle.basePosition.z + Math.cos(flightTime * 0.7) * jitter;
+
+          particle.mesh.position.set(x, y, z);
+
+          const material = particle.mesh.material as THREE.MeshLambertMaterial;
           const glowIntensity = 0.4 + range.audioLevel * 0.8;
-          
-          butterfly.wings.left.material.opacity = Math.min(1.0, baseBrightness);
-          butterfly.wings.right.material.opacity = Math.min(1.0, baseBrightness);
-          
-          butterfly.wings.left.material.emissiveIntensity = glowIntensity;
-          butterfly.wings.right.material.emissiveIntensity = glowIntensity;
-          butterfly.body.material.emissiveIntensity = glowIntensity * 0.5;
+          material.emissiveIntensity = glowIntensity;
         }
       });
     });
-
-    this.updatePetals(deltaTime);
 
     const radius = this.currentConfig.radius;
     const cameraSpeed = 0.12;
@@ -521,15 +380,16 @@ class AnalysisSpectrum extends BasePreset {
 
   updateConfig(newConfig: any): void {
     this.currentConfig = { ...this.currentConfig, ...newConfig };
-    
-    Object.entries(this.butterflyGroups).forEach(([key, range]) => {
+
+    Object.entries(this.particleGroups).forEach(([key, range]) => {
       const newColor = this.currentConfig.colors[key as BandName];
       if (newColor && newColor !== range.color) {
         range.color = newColor;
-        range.butterflies.forEach(butterfly => {
+        range.particles.forEach(particle => {
           const color = new THREE.Color(newColor);
-          butterfly.wings.left.material.color.copy(color);
-          butterfly.wings.right.material.color.copy(color);
+          const material = particle.mesh.material as THREE.MeshLambertMaterial;
+          material.color.copy(color);
+          material.emissive = color.clone().multiplyScalar(0.3);
         });
       }
     });
@@ -548,13 +408,11 @@ class AnalysisSpectrum extends BasePreset {
     this.camera.quaternion.copy(this.initialCameraQuaternion);
 
     this.group.clear();
-    this.wingGeometry?.dispose();
-    this.bodyGeometry?.dispose();
-    this.petalGeometry?.dispose();
+    this.particleGeometry?.dispose();
 
-    Object.keys(this.butterflyGroups).forEach(key => {
-      this.butterflyGroups[key as BandName] = {
-        butterflies: [],
+    Object.keys(this.particleGroups).forEach(key => {
+      this.particleGroups[key as BandName] = {
+        particles: [],
         color: '',
         centerX: 0,
         targetCount: 0,


### PR DESCRIPTION
## Summary
- Swap butterfly visualizer for smooth pastel-colored particles that fade in/out and orbit per frequency band
- Drive particle spawning by dB activity with configurable particle count and band colors

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'vite/client')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a742267b648333a50e0756658899ed