### PR TITLE
Ajustar canvas al ocultar la UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -23,7 +23,12 @@ body {
 
 .app.ui-hidden {
   display: flex;
+  flex-direction: column;
   grid-template-rows: none;
+}
+
+.app.ui-hidden .bottom-section {
+  flex: 1;
 }
 
 .app.ui-hidden .top-bar,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -558,6 +558,11 @@ const App: React.FC = () => {
     return () => window.removeEventListener('keydown', handler);
   }, [hideUiHotkey]);
 
+  // Recalcular el tamaño del canvas al mostrar/ocultar la UI
+  useEffect(() => {
+    window.dispatchEvent(new Event('resize'));
+  }, [isUiHidden]);
+
   // Handlers
   const handleFullScreen = useCallback(async () => {
     if ((window as any).electronAPI) {


### PR DESCRIPTION
## Summary
- Recalcula el tamaño del canvas al mostrar u ocultar la interfaz para eliminar el área vacía dejada por el grid.
- Ajusta los estilos cuando la UI está oculta para que la sección de visuales use todo el espacio disponible.

## Testing
- `npm test` *(falla: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a76737d9c08333bc5b2061da7c67aa