### PR TITLE
feat: improve preset drag and modal

### DIFF
--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -178,6 +178,10 @@
   outline: 2px dashed #666;
 }
 
+body.preset-dragging .preset-cell {
+  outline: 2px dashed #444;
+}
+
 /* CORRECCIÓN 3: Thumbnail mejorado */
 .preset-thumbnail {
   width: 100%;

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -93,6 +93,11 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
     index: number
   ) => {
     e.dataTransfer.setData('application/json', JSON.stringify({ layerId, index }));
+    document.body.classList.add('preset-dragging');
+  };
+
+  const handleDragEnd = () => {
+    document.body.classList.remove('preset-dragging');
   };
 
   const handleDragEnter = (
@@ -115,6 +120,21 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
     e.preventDefault();
     setDragTarget(null);
     const data = e.dataTransfer.getData('application/json');
+    const presetId = e.dataTransfer.getData('text/plain');
+
+    if (presetId) {
+      setLayerPresets(prev => {
+        const next = { ...prev };
+        const list = [...next[targetLayerId]];
+        if (!canPlace(list, presetId, targetIndex)) return prev;
+        list[targetIndex] = presetId;
+        next[targetLayerId] = list;
+        return next;
+      });
+      document.body.classList.remove('preset-dragging');
+      return;
+    }
+
     if (!data) return;
     const { layerId: sourceLayerId, index: sourceIndex } = JSON.parse(data);
     if (sourceLayerId === undefined) return;
@@ -144,6 +164,7 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
       next[targetLayerId] = targetList;
       return next;
     });
+    document.body.classList.remove('preset-dragging');
   };
 
   const handlePresetClick = (layerId: string, presetId: string, velocity?: number) => {
@@ -296,6 +317,7 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
                   onClick={() => handlePresetClick(layer.id, preset.id)}
                   draggable
                   onDragStart={(e) => handleDragStart(e, layer.id, idx)}
+                  onDragEnd={handleDragEnd}
                   onDragOver={handleDragOver}
                   onDragEnter={(e) => handleDragEnter(e, layer.id, idx)}
                   onDragLeave={handleDragLeave}

--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -9,6 +9,12 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  transition: opacity 0.2s ease;
+}
+
+.preset-gallery-overlay.dragging {
+  opacity: 0.2;
+  pointer-events: none;
 }
 
 .preset-gallery-modal {
@@ -25,24 +31,16 @@
 .preset-gallery-grid {
   flex: 1;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
   gap: 10px;
   padding: 10px;
   overflow-y: auto;
+  justify-items: center;
 }
 
 .preset-gallery-item {
-  background: #333;
-  border-radius: 4px;
-  padding: 8px;
-  text-align: center;
   cursor: pointer;
   user-select: none;
-}
-
-.preset-gallery-thumb {
-  font-size: 32px;
-  margin-bottom: 4px;
 }
 
 .preset-gallery-controls {

--- a/src/components/PresetGalleryModal.tsx
+++ b/src/components/PresetGalleryModal.tsx
@@ -16,23 +16,55 @@ export const PresetGalleryModal: React.FC<PresetGalleryModalProps> = ({
   presets
 }) => {
   const [selected, setSelected] = useState<LoadedPreset | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const getPresetThumbnail = (preset: LoadedPreset): string => {
+    const thumbnails: Record<string, string> = {
+      'neural_network': '🧠',
+      'abstract-lines': '📈',
+      'abstract-lines-pro': '📊',
+      'abstract-shapes': '🔷',
+      'evolutive-particles': '✨',
+      'boom-wave': '💥',
+      'plasma-ray': '⚡',
+      'shot-text': '📝',
+      'text-glitch': '🔤'
+    };
+    return thumbnails[preset.id] || '🎨';
+  };
 
   if (!isOpen) return null;
 
   return (
-    <div className="preset-gallery-overlay" onClick={onClose}>
+    <div className={`preset-gallery-overlay ${isDragging ? 'dragging' : ''}`} onClick={onClose}>
       <div className="preset-gallery-modal" onClick={e => e.stopPropagation()}>
         <div className="preset-gallery-grid">
           {presets.map(preset => (
             <div
               key={preset.id}
-              className="preset-gallery-item"
+              className="preset-gallery-item preset-cell"
               onClick={() => setSelected(preset)}
               draggable
-              onDragStart={(e) => e.dataTransfer.setData('text/plain', preset.id)}
+              onDragStart={(e) => {
+                e.dataTransfer.setData('text/plain', preset.id);
+                setIsDragging(true);
+                document.body.classList.add('preset-dragging');
+              }}
+              onDragEnd={() => {
+                setIsDragging(false);
+                document.body.classList.remove('preset-dragging');
+              }}
             >
-              <div className="preset-gallery-thumb">{preset.config.thumbnail || '🎨'}</div>
-              <div className="preset-gallery-name">{preset.config.name}</div>
+              {preset.config.note !== undefined && (
+                <div className="preset-note-badge">{preset.config.note}</div>
+              )}
+              <div className="preset-thumbnail">{getPresetThumbnail(preset)}</div>
+              <div className="preset-info">
+                <div className="preset-name">{preset.config.name}</div>
+                <div className="preset-details">
+                  <span className="preset-category">{preset.config.category}</span>
+                </div>
+              </div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- allow dragging presets from modal and grid into main grid
- mimic grid preset style in the modal and fade modal while dragging
- highlight grid pad containers while dragging

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a84ac72c2083339b637a1c00223178