### PR TITLE
Improve preset gallery drag and grid visuals

### DIFF
--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -182,6 +182,13 @@ body.preset-dragging .preset-cell {
   outline: 2px dashed #444;
 }
 
+body.preset-dragging .preset-grid {
+  background-image:
+    linear-gradient(#333 1px, transparent 1px),
+    linear-gradient(90deg, #333 1px, transparent 1px);
+  background-size: 100px 100px;
+}
+
 /* CORRECCIÓN 3: Thumbnail mejorado */
 .preset-thumbnail {
   width: 100%;

--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -14,6 +14,10 @@
 
 .preset-gallery-overlay.dragging {
   opacity: 0.2;
+}
+
+.preset-gallery-overlay.dragging,
+.preset-gallery-overlay.dragging .preset-gallery-modal {
   pointer-events: none;
 }
 
@@ -31,11 +35,13 @@
 .preset-gallery-grid {
   flex: 1;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
-  gap: 10px;
-  padding: 10px;
+  grid-template-columns: repeat(auto-fill, 96px);
+  grid-auto-rows: 96px;
+  gap: 2px;
+  padding: 2px;
   overflow-y: auto;
-  justify-items: center;
+  background: #0F0F0F;
+  justify-items: start;
 }
 
 .preset-gallery-item {


### PR DESCRIPTION
## Summary
- Allow presets to be dragged from gallery to main grid by disabling pointer events on gallery overlay during drag
- Tighten spacing in preset gallery so items align like main grid
- Highlight 100x100 drop zones in main grid when dragging presets

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Unable to find your web assets, did you forget to build your web app?)

------
https://chatgpt.com/codex/tasks/task_e_68a8550ddd748333a50ddc9c77c4c661