### PR TITLE
fix: stop auto-playing preset when added to layer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -797,33 +797,19 @@ const App: React.FC = () => {
     }
   };
 
-  // Handler para añadir preset a layer desde la galería
-  const handleAddPresetToLayer = async (presetId: string, layerId: string) => {
-    if (!engineRef.current) return;
-    
-    try {
-      await engineRef.current.activateLayerPreset(layerId, presetId);
-      setActiveLayers(prev => ({ ...prev, [layerId]: presetId }));
+  // Handler para añadir preset a layer desde la galería sin activarlo
+  const handleAddPresetToLayer = (presetId: string, layerId: string) => {
+    const addFn = (window as any).addPresetToLayer as
+      | ((layerId: string, presetId: string) => void)
+      | undefined;
 
-      const preset = availablePresets.find(p => p.id === presetId);
-      if (preset) {
-        const existing = layerPresetConfigs[layerId]?.[presetId];
-        if (existing) {
-          applyPresetConfig(engineRef.current, layerId, existing);
-        } else {
-          const cfg = engineRef.current.getLayerPresetConfig(layerId, presetId);
-          setLayerPresetConfigs(prev => ({
-            ...prev,
-            [layerId]: { ...(prev[layerId] || {}), [presetId]: cfg }
-          }));
-        }
-        setSelectedPreset(preset);
-        setSelectedLayer(layerId);
-        setStatus(`${preset.config.name} añadido a Layer ${layerId}`);
-      }
-    } catch (error) {
-      console.error('Error adding preset to layer:', error);
-      setStatus('Error al añadir preset');
+    if (typeof addFn !== 'function') return;
+
+    addFn(layerId, presetId);
+
+    const preset = availablePresets.find(p => p.id === presetId);
+    if (preset) {
+      setStatus(`${preset.config.name} añadido a Layer ${layerId}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- Avoid auto-playing presets when adding them from the gallery

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Unable to find web assets, distDir is "../dist")*

------
https://chatgpt.com/codex/tasks/task_e_68a86fd689548333acb1a51cf60b48e9