### PR TITLE
Enable preset modal on empty grid pads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -912,6 +912,7 @@ const App: React.FC = () => {
           }}
           clearAllSignal={clearSignal}
           layerChannels={layerChannels}
+          onOpenPresetGallery={() => setPresetGalleryOpen(true)}
         />
       </div>
 

--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -179,7 +179,7 @@
 .preset-cell.empty-slot {
   background: transparent;
   border: 1px dashed #333;
-  cursor: default;
+  cursor: pointer;
 }
 
 .preset-cell.empty-slot:hover {

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -20,6 +20,7 @@ interface LayerGridProps {
   clearAllSignal: number;
   externalTrigger?: { layerId: string; presetId: string; velocity: number } | null;
   layerChannels: Record<string, number>;
+  onOpenPresetGallery: () => void;
 }
 
 export const LayerGrid: React.FC<LayerGridProps> = ({
@@ -30,7 +31,8 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
   onPresetSelect,
   clearAllSignal,
   externalTrigger,
-  layerChannels
+  layerChannels,
+  onOpenPresetGallery
 }) => {
   const [layers, setLayers] = useState<LayerConfig[]>([
     { id: 'A', name: 'Layer A', color: '#FF6B6B', midiChannel: layerChannels.A || 14, fadeTime: 200, opacity: 100, activePreset: null },
@@ -402,6 +404,7 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
                   <div
                     key={`${layer.id}-empty-${idx}`}
                     className={`preset-cell empty-slot ${isDragOver ? 'drag-over' : ''}`}
+                    onClick={onOpenPresetGallery}
                     onDragOver={handleDragOver}
                     onDragEnter={(e) => handleDragEnter(e, layer.id, idx)}
                     onDragLeave={handleDragLeave}


### PR DESCRIPTION
## Summary
- Make empty layer grid slots open preset gallery
- Allow parent component to trigger preset gallery from grid
- Show pointer cursor for empty slots

## Testing
- `npx tsc -p tsconfig.json --noEmit` (fails: Property 'getExtension' does not exist on type 'RenderingContext')
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a88e2df7bc83338100a5935ee4c4f6