### PR TITLE
feat: add template-based presets and dynamic grid

### DIFF
--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -49,6 +49,27 @@
   font-weight: 600;
 }
 
+/* Tabs */
+.preset-gallery-tabs {
+  display: flex;
+  border-bottom: 1px solid #444;
+}
+
+.tab-button {
+  flex: 1;
+  background: #2a2a2a;
+  border: none;
+  color: #fff;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.tab-button.active {
+  background: #333;
+  font-weight: 600;
+}
+
 .close-button {
   background: none;
   border: none;
@@ -192,6 +213,21 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.custom-text-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.custom-text-inputs input {
+  background: #333;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 4px 6px;
+  border-radius: 4px;
 }
 
 .count-controls button:hover:not(:disabled) {

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -454,6 +454,12 @@ export class AudioVisualizerEngine {
     return this.presetLoader.getLoadedPresets();
   }
 
+  public async updateCustomTextTemplates(count: number, texts: string[]): Promise<LoadedPreset[]> {
+    this.presetLoader.setCustomTextInstances(count, texts);
+    await this.presetLoader.loadAllPresets();
+    return this.presetLoader.getLoadedPresets();
+  }
+
   public updateAudioData(audioData: AudioData): void {
     this.presetLoader.updateAudioData(audioData);
   }

--- a/src/core/PresetLoader.ts
+++ b/src/core/PresetLoader.ts
@@ -94,6 +94,7 @@ export interface LoadedPreset {
 export class PresetLoader {
   private loadedPresets: Map<string, LoadedPreset> = new Map();
   private activePresets: Map<string, BasePreset> = new Map();
+  private customTextContents: string[] = [];
 
   // Carga dinámica de presets desde el sistema de archivos
   private presetModules = import.meta.glob('../presets/*/preset.ts');
@@ -110,15 +111,19 @@ export class PresetLoader {
   ) {}
 
   public setGlitchTextPads(count: number): void {
-    const newCount = Math.max(1, Math.min(10, count)); // Límite entre 1 y 10
-    
-    if (newCount !== this.glitchTextPads) {
-      this.glitchTextPads = newCount;
-      console.log(`🔧 Custom text instances set to: ${this.glitchTextPads}`);
-      
-      // Recargar presets para aplicar el nuevo número
-      this.reloadCustomTextPresets();
+    // Mantener compatibilidad, reutilizando textos actuales
+    this.setCustomTextInstances(count, this.customTextContents);
+  }
+
+  public setCustomTextInstances(count: number, texts: string[]): void {
+    const newCount = Math.max(1, Math.min(10, count));
+    this.glitchTextPads = newCount;
+    this.customTextContents = texts.slice(0, newCount);
+    while (this.customTextContents.length < newCount) {
+      this.customTextContents.push(`Text ${this.customTextContents.length + 1}`);
     }
+    console.log(`🔧 Custom text instances set to: ${this.glitchTextPads}`);
+    this.reloadCustomTextPresets();
   }
 
   public getGlitchTextPads(): number {
@@ -162,12 +167,13 @@ export class PresetLoader {
       const baseNote = cfg.note!;
       for (let i = 1; i <= this.glitchTextPads; i++) {
         const cloneConfig = JSON.parse(JSON.stringify(cfg));
-        cloneConfig.name = `${cfg.name} ${i}`;
-        
+        const text = this.customTextContents[i - 1] || `Text ${i}`;
+        cloneConfig.name = text;
+
         if (cloneConfig.defaultConfig?.text?.content !== undefined) {
-          cloneConfig.defaultConfig.text.content = `Text ${i}`;
+          cloneConfig.defaultConfig.text.content = text;
         }
-        
+
         cloneConfig.note = baseNote + (i - 1);
         
         const clone: LoadedPreset = {
@@ -238,12 +244,13 @@ export class PresetLoader {
         
         for (let i = 1; i <= this.glitchTextPads; i++) {
           const cloneConfig = JSON.parse(JSON.stringify(cfg));
-          cloneConfig.name = `${cfg.name} ${i}`;
-          
+          const text = this.customTextContents[i - 1] || `Text ${i}`;
+          cloneConfig.name = text;
+
           if (cloneConfig.defaultConfig?.text?.content !== undefined) {
-            cloneConfig.defaultConfig.text.content = `Text ${i}`;
+            cloneConfig.defaultConfig.text.content = text;
           }
-          
+
           cloneConfig.note = baseNote + (i - 1);
           
           const clone: LoadedPreset = {


### PR DESCRIPTION
## Summary
- compute layer slot count from window width and adjust on resize
- split preset gallery into tabs and move custom text into template tab with configurable instances
- support custom text templates throughout engine and persist settings

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc -p tsconfig.json --noEmit` (fails: Cannot find module 'fs'...)


------
https://chatgpt.com/codex/tasks/task_e_68a8a01acc648333ab458b6471b3ce3e