### PR TITLE
Ensure visuals use full-screen transparent canvas

### DIFF
--- a/clone.html
+++ b/clone.html
@@ -9,7 +9,7 @@
       padding: 0;
       width: 100%;
       height: 100%;
-      background: #000;
+      background: transparent;
       display: flex;
       justify-content: center;
       align-items: center;
@@ -18,6 +18,7 @@
       width: 100%;
       height: 100%;
       display: block;
+      background: transparent;
     }
   </style>
 </head>

--- a/src/App.css
+++ b/src/App.css
@@ -6,9 +6,14 @@
   box-sizing: border-box;
 }
 
+html, body, #root {
+  width: 100%;
+  height: 100%;
+  background: transparent;
+}
+
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background: #000;
   color: #fff;
   overflow: hidden;
 }
@@ -54,7 +59,7 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
-  background: #000;
+  background: transparent;
   z-index: 0;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -180,14 +180,19 @@ const App: React.FC = () => {
       if ((window as any).electronAPI?.getDisplays) {
         try {
           const displays = await (window as any).electronAPI.getDisplays();
-          const mapped: MonitorInfo[] = displays.map((d: any) => ({
-            id: d.id.toString(),
-            label: `${d.label} (${d.bounds.width}x${d.bounds.height})`,
-            position: { x: d.bounds.x, y: d.bounds.y },
-            size: { width: d.bounds.width, height: d.bounds.height },
-            isPrimary: d.primary,
-            scaleFactor: d.scaleFactor || 1
-          }));
+          const mapped: MonitorInfo[] = displays.map((d: any) => {
+            const scale = d.scaleFactor || 1;
+            const width = d.bounds.width * scale;
+            const height = d.bounds.height * scale;
+            return {
+              id: d.id.toString(),
+              label: `${d.label} (${width}x${height})`,
+              position: { x: d.bounds.x, y: d.bounds.y },
+              size: { width, height },
+              isPrimary: d.primary,
+              scaleFactor: scale
+            };
+          });
           mapped.sort((a, b) => {
             if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
             return a.position.x - b.position.x;

--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -188,16 +188,8 @@ export class AudioVisualizerEngine {
   }
 
   private updateSize(): void {
-    const rect = this.canvas.getBoundingClientRect();
-    let width = rect.width;
-    let height = rect.height;
-
-    // Al ir a fullscreen el canvas puede reportar 0x0 temporalmente.
-    // Evitamos propagar esos valores para no crear render targets inválidos.
-    if (width === 0 || height === 0) {
-      width = window.innerWidth;
-      height = window.innerHeight;
-    }
+    const width = window.innerWidth;
+    const height = window.innerHeight;
     const pixelRatio = Math.min(window.devicePixelRatio, 2);
     const visualScale = parseFloat(localStorage.getItem('visualScale') || '1');
     const scaledWidth = width * visualScale;

--- a/src/presets/ambient-tunnel/preset.ts
+++ b/src/presets/ambient-tunnel/preset.ts
@@ -34,7 +34,7 @@ class AmbientTunnelPreset extends BasePreset {
   }
 
   init(): void {
-    this.renderer.setClearColor(0x000000, 1);
+    this.renderer.setClearColor(0x000000, 0);
     for (let i = 0; i < 20; i++) {
       const geo = new THREE.TorusGeometry(1, 0.05, 16, 64);
       const mat = new THREE.MeshBasicMaterial({ color: this.currentConfig.color, transparent: true, opacity: 0.3 });

--- a/src/presets/custom-glitch-text/preset.ts
+++ b/src/presets/custom-glitch-text/preset.ts
@@ -162,8 +162,14 @@ class CustomGlitchTextPreset extends BasePreset {
     this.ctx = this.canvas.getContext('2d')!;
     this.texture = new THREE.Texture(this.canvas);
     this.texture.needsUpdate = true;
+    const cam = this.camera as THREE.PerspectiveCamera;
+    const distance = cam.position.z;
+    const vFov = THREE.MathUtils.degToRad(cam.fov);
+    const visibleHeight = 2 * Math.tan(vFov / 2) * distance;
+    const visibleWidth = visibleHeight * cam.aspect;
+    const planeHeight = visibleWidth / 4; // mantener proporción 4:1 del canvas
     this.mesh = new THREE.Mesh(
-      new THREE.PlaneGeometry(2, 0.5),
+      new THREE.PlaneGeometry(visibleWidth, planeHeight),
       new THREE.MeshBasicMaterial({ map: this.texture, transparent: true, color: new THREE.Color(this.currentConfig.color) })
     );
     this.group.add(this.mesh);
@@ -182,6 +188,13 @@ class CustomGlitchTextPreset extends BasePreset {
       this.group.add(letter.glow);
       this.letters.push(letter);
     }
+    const cam = this.camera as THREE.PerspectiveCamera;
+    const distance = cam.position.z;
+    const vFov = THREE.MathUtils.degToRad(cam.fov);
+    const visibleHeight = 2 * Math.tan(vFov / 2) * distance;
+    const visibleWidth = visibleHeight * cam.aspect;
+    const scale = visibleWidth / totalWidth;
+    this.group.scale.set(scale, scale, 1);
     this.start = this.clock.getElapsedTime();
   }
 

--- a/src/presets/neon-grid-sun/preset.ts
+++ b/src/presets/neon-grid-sun/preset.ts
@@ -40,7 +40,7 @@ class ParticleGridSunPreset extends BasePreset {
   }
 
   init(): void {
-    this.renderer.setClearColor(0x000000, 1);
+    this.renderer.setClearColor(0x000000, 0);
     const count = 100;
     const radius = 3;
 


### PR DESCRIPTION
## Summary
- Force canvas and document to occupy full viewport with transparent background
- Report monitor resolutions using physical pixels and resize renderer to window size
- Guarantee presets render on transparent background and custom text scales to canvas width

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'getExtension' does not exist on type 'RenderingContext', etc.)*
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_68a8a65694a883338e8c263b3991f707