### PR TITLE
Add layer effects with MIDI triggers

### DIFF
--- a/src/components/GlobalSettingsModal.css
+++ b/src/components/GlobalSettingsModal.css
@@ -235,6 +235,26 @@
   font-weight: 500;
 }
 
+.layer-effect-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.layer-effect-settings h5 {
+  margin: 0;
+  font-size: 14px;
+  color: #ccc;
+  font-weight: 500;
+}
+
+.effect-setting {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .setting-select:focus,
 .setting-slider:focus,
 .setting-number:focus {

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import './GlobalSettingsModal.css';  // ✅ AÑADIR ESTE IMPORT
+import { AVAILABLE_EFFECTS } from '../utils/effects';
 
 interface DeviceOption {
   id: string;
@@ -34,6 +35,9 @@ interface GlobalSettingsModalProps {
   onMidiClockTypeChange: (value: string) => void;
   layerChannels: Record<string, number>;
   onLayerChannelChange: (layerId: string, channel: number) => void;
+  layerEffects: Record<string, { effect: string; midiNote: number }>;
+  onLayerEffectChange: (layerId: string, effect: string) => void;
+  onLayerEffectNoteChange: (layerId: string, note: number) => void;
   monitors: MonitorInfo[];
   monitorRoles: Record<string, 'main' | 'secondary' | 'none'>;
   onMonitorRoleChange: (id: string, role: 'main' | 'secondary' | 'none') => void;
@@ -78,6 +82,9 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
   onMidiClockTypeChange,
   layerChannels,
   onLayerChannelChange,
+  layerEffects,
+  onLayerEffectChange,
+  onLayerEffectNoteChange,
   monitors,
   monitorRoles,
   onMonitorRoleChange,
@@ -386,6 +393,31 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
                         max={16}
                         value={layerChannels[id]}
                         onChange={(e) => onLayerChannelChange(id, parseInt(e.target.value) || 1)}
+                        className="setting-number"
+                      />
+                    </label>
+                  ))}
+                </div>
+                <div className="layer-effect-settings">
+                  <h5>Efectos por Layer</h5>
+                  {['A','B','C'].map(id => (
+                    <label key={id} className="setting-label effect-setting">
+                      <span>Layer {id}</span>
+                      <select
+                        value={layerEffects[id].effect}
+                        onChange={(e) => onLayerEffectChange(id, e.target.value)}
+                        className="setting-select"
+                      >
+                        {AVAILABLE_EFFECTS.map(eff => (
+                          <option key={eff} value={eff}>{eff}</option>
+                        ))}
+                      </select>
+                      <input
+                        type="number"
+                        min={0}
+                        max={127}
+                        value={layerEffects[id].midiNote}
+                        onChange={(e) => onLayerEffectNoteChange(id, parseInt(e.target.value) || 0)}
                         className="setting-number"
                       />
                     </label>

--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -1,28 +1,36 @@
-.layer-grid {
+ .layer-grid {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background: #0A0A0A;
   color: #FFFFFF;
   padding: 0;
-  height: 300px; /* Altura fija para 3 capas */
+  height: 360px; /* Altura fija ajustada para headers */
   overflow: hidden; /* Sin scroll, todo visible */
 }
 
 /* Layer Section - 100px cada una */
 .layer-section {
-  height: 100px; /* Altura fija: controles + grid */
+  height: 120px; /* Contenido + header */
   background: #111111;
   border-bottom: 1px solid #000000;
   display: flex;
+  flex-direction: column;
   gap: 1px;
+  position: relative;
 }
 
 .layer-section:first-child {
   border-top: 1px solid #000000;
 }
 
+.layer-content {
+  flex: 1;
+  display: flex;
+  gap: 1px;
+}
+
 .layer-sidebar {
   width: 100px;
-  height: 100px;
+  height: 100%;
   background: linear-gradient(135deg, #1A1A1A, #161616);
   border-left: 3px solid var(--layer-color, #666);
   display: flex;
@@ -101,7 +109,7 @@
 
 /* Preset Grid */
 .preset-grid {
-  height: 96px; /* Más espacio para contenido interno */
+  height: 100%;
   display: flex;
   gap: 1px;
   padding: 1px;
@@ -110,6 +118,68 @@
   overflow-y: hidden;
   scrollbar-width: thin;
   scrollbar-color: #333 #111;
+}
+
+.layer-header {
+  height: 20px;
+  display: flex;
+  align-items: center;
+  padding: 0 4px;
+  background: #1a1a1a;
+  border: 2px solid transparent;
+}
+
+.layer-header.effect-active {
+  border-color: #39ff14;
+}
+
+.layer-header select {
+  width: 100px;
+  background: #222;
+  color: #fff;
+  border: 1px solid #333;
+  font-size: 10px;
+  height: 16px;
+}
+
+/* Effect styles */
+.layer-section.effect-blur { filter: blur(3px); }
+.layer-section.effect-distortion { transform: skewX(5deg); }
+.layer-section.effect-pixelate { image-rendering: pixelated; transform: scale(1.05); }
+.layer-section.effect-invert { filter: invert(1); }
+.layer-section.effect-sepia { filter: sepia(1); }
+.layer-section.effect-noise { animation: noise 0.2s steps(5) infinite; }
+.layer-section.effect-scanlines { background-image: repeating-linear-gradient(to bottom, rgba(255,255,255,0.05) 0, rgba(255,255,255,0.05) 1px, transparent 1px, transparent 2px); }
+.layer-section.effect-glitch1 { animation: glitch1 0.5s infinite; }
+.layer-section.effect-glitch2 { animation: glitch2 0.5s infinite; }
+.layer-section.effect-glitch3 { animation: glitch3 0.5s infinite; }
+
+@keyframes glitch1 {
+  0% { transform: translate(0); }
+  20% { transform: translate(-2px,2px); }
+  40% { transform: translate(2px,-2px); }
+  60% { transform: translate(-1px,1px); }
+  80% { transform: translate(1px,-1px); }
+  100% { transform: translate(0); }
+}
+
+@keyframes glitch2 {
+  0% { transform: skewX(0deg); }
+  25% { transform: skewX(5deg); }
+  50% { transform: skewX(-5deg); }
+  75% { transform: skewX(3deg); }
+  100% { transform: skewX(0deg); }
+}
+
+@keyframes glitch3 {
+  0% { filter: hue-rotate(0deg); }
+  50% { filter: hue-rotate(180deg); }
+  100% { filter: hue-rotate(0deg); }
+}
+
+@keyframes noise {
+  0%,100% { background-position: 0 0; }
+  50% { background-position: 10px 10px; }
 }
 
 .preset-grid::-webkit-scrollbar {

--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { LoadedPreset } from '../core/PresetLoader';
+import { AVAILABLE_EFFECTS } from '../utils/effects';
 
 interface LayerConfig {
   id: string;
@@ -21,6 +22,8 @@ interface LayerGridProps {
   externalTrigger?: { layerId: string; presetId: string; velocity: number } | null;
   layerChannels: Record<string, number>;
   onOpenPresetGallery: () => void;
+  layerEffects: Record<string, { effect: string; midiNote: number; active: boolean }>;
+  onLayerEffectChange: (layerId: string, effect: string) => void;
 }
 
 export const LayerGrid: React.FC<LayerGridProps> = ({
@@ -32,7 +35,9 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
   clearAllSignal,
   externalTrigger,
   layerChannels,
-  onOpenPresetGallery
+  onOpenPresetGallery,
+  layerEffects,
+  onLayerEffectChange
 }) => {
   const [layers, setLayers] = useState<LayerConfig[]>([
     { id: 'A', name: 'Layer A', color: '#FF6B6B', midiChannel: layerChannels.A || 14, fadeTime: 200, opacity: 100, activePreset: null },
@@ -402,51 +407,70 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
   return (
     <div className="layer-grid">
       {layers.map((layer) => (
-        <div key={layer.id} className="layer-section">
-          {/* Layer Controls - 100x100 square */}
+        <div
+          key={layer.id}
+          className={`layer-section ${layerEffects[layer.id]?.active ? `effect-${layerEffects[layer.id].effect}` : ''}`}
+        >
           <div
-            className="layer-sidebar"
-            style={{ borderLeftColor: layer.color }}
+            className={`layer-header ${layerEffects[layer.id]?.active ? 'effect-active' : ''}`}
           >
-            <div className="layer-letter" style={{ color: layer.color }}>
-              {layer.id}
-            </div>
-            <div className="midi-channel-label">CH {layer.midiChannel}</div>
-            <div className="sidebar-controls">
-              <input
-                type="range"
-                value={layer.opacity}
-                onChange={(e) =>
-                  handleLayerConfigChange(layer.id, 'opacity', parseInt(e.target.value))
-                }
-                className="opacity-slider"
-                min="0"
-                max="100"
-              />
-              <div className="fade-control">
-                <input
-                  type="number"
-                  value={layer.fadeTime}
-                  onChange={(e) =>
-                    handleLayerConfigChange(
-                      layer.id,
-                      'fadeTime',
-                      parseInt(e.target.value)
-                    )
-                  }
-                  className="fade-input"
-                  min="0"
-                  max="5000"
-                  step="50"
-                />
-                <span className="unit">ms</span>
-              </div>
-            </div>
+            <select
+              value={layerEffects[layer.id]?.effect}
+              onChange={(e) => onLayerEffectChange(layer.id, e.target.value)}
+            >
+              {AVAILABLE_EFFECTS.map((eff) => (
+                <option key={eff} value={eff}>
+                  {eff}
+                </option>
+              ))}
+            </select>
           </div>
 
-          {/* Preset Grid con slots fijos */}
-          <div className="preset-grid">
-            {layerPresets[layer.id].map((presetId, idx) => {
+          {/* Layer Controls - 100x100 square */}
+          <div className="layer-content">
+            <div
+              className="layer-sidebar"
+              style={{ borderLeftColor: layer.color }}
+            >
+              <div className="layer-letter" style={{ color: layer.color }}>
+                {layer.id}
+              </div>
+              <div className="midi-channel-label">CH {layer.midiChannel}</div>
+              <div className="sidebar-controls">
+                <input
+                  type="range"
+                  value={layer.opacity}
+                  onChange={(e) =>
+                    handleLayerConfigChange(layer.id, 'opacity', parseInt(e.target.value))
+                  }
+                  className="opacity-slider"
+                  min="0"
+                  max="100"
+                />
+                <div className="fade-control">
+                  <input
+                    type="number"
+                    value={layer.fadeTime}
+                    onChange={(e) =>
+                      handleLayerConfigChange(
+                        layer.id,
+                        'fadeTime',
+                        parseInt(e.target.value)
+                      )
+                    }
+                    className="fade-input"
+                    min="0"
+                    max="5000"
+                    step="50"
+                  />
+                  <span className="unit">ms</span>
+                </div>
+              </div>
+            </div>
+
+            {/* Preset Grid con slots fijos */}
+            <div className="preset-grid">
+              {layerPresets[layer.id].map((presetId, idx) => {
               // Slot vacío
               if (!presetId) {
                 const isDragOver = dragTarget?.layerId === layer.id && dragTarget.index === idx;
@@ -520,6 +544,7 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
               );
             })}
           </div>
+        </div>
         </div>
       ))}
     </div>

--- a/src/utils/effects.ts
+++ b/src/utils/effects.ts
@@ -1,0 +1,13 @@
+export const AVAILABLE_EFFECTS = [
+  'none',
+  'glitch1',
+  'glitch2',
+  'glitch3',
+  'blur',
+  'distortion',
+  'pixelate',
+  'invert',
+  'sepia',
+  'noise',
+  'scanlines'
+];


### PR DESCRIPTION
## Summary
- introduce selectable visual effects for each layer
- allow configuring MIDI note triggers for effects and show active state
- ensure Clear All resets any active effects

## Testing
- `npm run build` *(fails: Unable to find web assets)*
- `npx tsc --noEmit` *(fails: Cannot find module 'fs' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aa0d1c608333a72001c47770edfb