### PR TITLE
Add layer bar controls and integrate preset panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1067,6 +1067,7 @@ const App: React.FC = () => {
           onLayerEffectChange={handleLayerEffectChange}
           onLayerEffectToggle={handleLayerEffectToggle}
           onOpenPresetGallery={() => setPresetGalleryOpen(true)}
+          bpm={bpm}
         />
       </div>
 

--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -47,11 +47,6 @@
   font-weight: 600;
 }
 
-.midi-channel-label {
-  font-size: 10px;
-  color: #bbb;
-}
-
 .sidebar-controls {
   display: flex;
   flex-direction: column;
@@ -127,6 +122,7 @@
   padding: 0 4px;
   background: #1a1a1a;
   border: 2px solid transparent;
+  gap: 4px;
 }
 
 .layer-header.effect-active {
@@ -152,6 +148,38 @@
 
 .effect-always input {
   margin: 0;
+}
+
+.midi-channel-edit {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 10px;
+}
+
+.midi-channel-input {
+  width: 30px;
+  background: #222;
+  color: #fff;
+  border: 1px solid #333;
+  font-size: 10px;
+  height: 16px;
+}
+
+.jump-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+}
+
+.jump-controls select,
+.jump-controls input {
+  background: #222;
+  color: #fff;
+  border: 1px solid #333;
+  height: 16px;
+  font-size: 10px;
 }
 
 /* Effect styles */

--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -146,19 +146,22 @@
 .preset-gallery-content {
   flex: 1;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   height: calc(100% - 80px);
 }
 
 /* Sections */
 .preset-gallery-section {
-  flex: 1;
-  padding: 20px;
-  border-bottom: 1px solid #333;
+  flex: none;
+  width: 140px;
+  padding: 20px 10px;
+  border-right: 1px solid #333;
+  border-bottom: none;
+  overflow-y: auto;
 }
 
 .preset-gallery-section:last-of-type {
-  border-bottom: none;
+  border-right: none;
 }
 
 .preset-gallery-section h3 {
@@ -340,13 +343,14 @@
 
 /* Controls Panel */
 .preset-gallery-controls {
-  width: 100%;
-  max-width: 400px;
-  min-height: 200px;
-  border-top: 1px solid #444;
+  flex: 1;
+  width: auto;
+  max-width: none;
+  min-height: auto;
+  border-left: 1px solid #444;
+  border-top: none;
   overflow-y: auto;
   background: #1a1a1a;
-  flex-shrink: 0;
 }
 
 .controls-panel {
@@ -732,51 +736,3 @@
   }
 }
 
-/* Integrated controls layout - vertical preset list with right panel */
-.preset-gallery-content {
-  flex-direction: row;
-}
-
-.preset-gallery-section {
-  flex: none;
-  width: 140px;
-  padding: 20px 10px;
-  border-right: 1px solid #333;
-  border-bottom: none;
-  overflow-y: auto;
-}
-
-.preset-gallery-grid {
-  grid-template-columns: 1fr;
-  grid-auto-rows: 140px;
-  gap: 10px;
-  max-height: none;
-  height: 100%;
-}
-
-.preset-gallery-controls {
-  flex: 1;
-  width: auto;
-  max-width: none;
-  min-height: auto;
-  border-left: 1px solid #444;
-  border-top: none;
-}
-
-@media (max-width: 768px) {
-  .preset-gallery-content {
-    flex-direction: column;
-  }
-
-  .preset-gallery-section {
-    width: 100%;
-    border-right: none;
-    border-bottom: 1px solid #333;
-    height: auto;
-  }
-
-  .preset-gallery-controls {
-    border-left: none;
-    border-top: 1px solid #444;
-  }
-}


### PR DESCRIPTION
## Summary
- Inline preset controls in gallery modal
- Add per-layer MIDI channel and auto-jump settings
- Support time or beat-based pad sequencing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8af2e5c80833385df62f3f0ea0c34