### PR TITLE
Fix LayerGrid JSX closing tags causing build failure

### DIFF
--- a/src/components/LayerGrid.tsx
+++ b/src/components/LayerGrid.tsx
@@ -461,7 +461,8 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
 
   return (
     <div className="layer-grid">
-      {layers.map((layer) => (
+      {layers.map((layer) => {
+        return (
         <div
           key={layer.id}
           className={`layer-section ${layerEffects[layer.id]?.active ? `effect-${layerEffects[layer.id].effect}` : ''}`}
@@ -656,9 +657,11 @@ export const LayerGrid: React.FC<LayerGridProps> = ({
                 </div>
               );
             })}
+            </div>
           </div>
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Correct JSX return structure in LayerGrid to close divs and map expression properly

## Testing
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_68a8b1228bf083339612d938288c824e