### PR TITLE
Improve layer grid spacing and isolate glitch effects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1079,12 +1079,12 @@ const App: React.FC = () => {
       {/* Sección inferior con visuales y controles */}
       <div className="bottom-section">
         <div
-          className={`visual-wrapper ${activeEffectClasses}`}
+          className="visual-wrapper"
           style={{ background: canvasBackground }}
         >
           <canvas
             ref={canvasRef}
-            className="main-canvas"
+            className={`main-canvas ${activeEffectClasses}`}
             style={{
               filter: `brightness(${canvasBrightness}) saturate(${canvasVibrance})`
             }}

--- a/src/components/LayerGrid.css
+++ b/src/components/LayerGrid.css
@@ -1,14 +1,16 @@
- .layer-grid {
+.layer-grid {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background: #0A0A0A;
   color: #FFFFFF;
   padding: 0;
-  height: 360px; /* Altura fija ajustada para headers */
-  overflow: hidden; /* Sin scroll, todo visible */
+  /* Altura dinámica para evitar cortes en la última layer */
+  /* height: 360px;  Altura fija ajustada para headers */
+  /* overflow: hidden;  Sin scroll, todo visible */
 }
 
 /* Layer Section - 100px cada una */
 .layer-section {
+  margin-top: 2px; /* Separación entre layers */
   height: 120px; /* Contenido + header */
   background: #111111;
   border-bottom: 1px solid #000000;
@@ -19,6 +21,7 @@
 }
 
 .layer-section:first-child {
+  margin-top: 0;
   border-top: 1px solid #000000;
 }
 


### PR DESCRIPTION
## Summary
- Allow grid height to expand so all layers remain visible
- Add 2px dark margin separating layer rows for clearer distinction
- Apply glitch effect classes directly to the canvas to avoid altering the canvas background

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8b8da2b0083338eebe0f207ca9950