### PR TITLE
Rediseño de preferencias con navegación lateral

### DIFF
--- a/src/components/GlobalSettingsModal.css
+++ b/src/components/GlobalSettingsModal.css
@@ -19,10 +19,10 @@
   background: linear-gradient(135deg, #1a1a1a, #2a2a2a);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;
-  width: 90vw;
-  max-width: 900px;
-  height: 85vh;
-  max-height: 700px;
+  width: 80vw;
+  max-width: 800px;
+  height: 75vh;
+  max-height: 600px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -48,7 +48,7 @@
 
 /* Header */
 .settings-header {
-  padding: 20px 30px;
+  padding: 15px 20px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   display: flex;
   align-items: center;
@@ -59,7 +59,7 @@
 .settings-header h2 {
   color: #64B5F6;
   margin: 0;
-  font-size: 24px;
+  font-size: 20px;
   font-weight: 600;
 }
 
@@ -68,8 +68,8 @@
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 8px;
   color: #fff;
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -82,18 +82,25 @@
   transform: scale(1.05);
 }
 
-/* Tabs */
-.settings-tabs {
+/* Layout */
+.settings-main {
+  flex: 1;
   display: flex;
-  padding: 0 30px;
-  background: rgba(0, 0, 0, 0.2);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  overflow-x: auto;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
+  overflow: hidden;
 }
 
-.settings-tabs::-webkit-scrollbar {
+/* Sidebar */
+.settings-sidebar {
+  width: 180px;
+  background: rgba(0, 0, 0, 0.2);
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.settings-sidebar::-webkit-scrollbar {
   display: none;
 }
 
@@ -101,16 +108,17 @@
   background: transparent;
   border: none;
   color: #ccc;
-  padding: 15px 20px;
+  padding: 10px 20px;
   cursor: pointer;
   transition: all 0.2s ease;
-  border-bottom: 3px solid transparent;
-  white-space: nowrap;
+  border-left: 3px solid transparent;
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
+  width: 100%;
+  text-align: left;
 }
 
 .tab-button:hover {
@@ -120,7 +128,7 @@
 
 .tab-button.active {
   color: #64B5F6;
-  border-bottom-color: #64B5F6;
+  border-left-color: #64B5F6;
   background: rgba(100, 181, 246, 0.1);
 }
 
@@ -132,7 +140,7 @@
 .settings-content {
   flex: 1;
   overflow-y: auto;
-  padding: 30px;
+  padding: 20px;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.3) rgba(255, 255, 255, 0.1);
 }
@@ -157,8 +165,8 @@
 
 .settings-section h3 {
   color: #81C784;
-  margin: 0 0 25px 0;
-  font-size: 20px;
+  margin: 0 0 20px 0;
+  font-size: 18px;
   font-weight: 600;
   display: flex;
   align-items: center;
@@ -167,8 +175,8 @@
 
 /* Setting Groups */
 .setting-group {
-  margin-bottom: 25px;
-  padding: 20px;
+  margin-bottom: 20px;
+  padding: 15px;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 12px;
@@ -182,17 +190,17 @@
 
 .setting-group h4 {
   color: #FFB74D;
-  margin: 0 0 15px 0;
-  font-size: 16px;
+  margin: 0 0 12px 0;
+  font-size: 14px;
   font-weight: 600;
 }
 
 .setting-label {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   color: #fff;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
 }
 
@@ -207,8 +215,8 @@
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 8px;
   color: #fff;
-  padding: 10px 12px;
-  font-size: 14px;
+  padding: 8px 10px;
+  font-size: 13px;
   transition: all 0.2s ease;
 }
 
@@ -300,13 +308,13 @@
   align-items: center;
   gap: 12px;
   color: #fff;
-  font-size: 14px;
+  font-size: 13px;
   cursor: pointer;
 }
 
 .setting-checkbox input[type="checkbox"] {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   accent-color: #64B5F6;
   cursor: pointer;
 }

--- a/src/components/GlobalSettingsModal.tsx
+++ b/src/components/GlobalSettingsModal.tsx
@@ -238,28 +238,28 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
           <button className="close-button" onClick={onClose}>✕</button>
         </div>
 
-        {/* Tabs */}
-        <div className="settings-tabs">
-          {[
-            { id: 'audio', label: 'Audio', icon: '🎵' },
-            { id: 'video', label: 'Rendimiento', icon: '🎮' },
-            { id: 'fullscreen', label: 'Monitores', icon: '🖥️' },
-            { id: 'visual', label: 'Visuales', icon: '🎨' },
-            { id: 'system', label: 'Sistema', icon: '🔧' }
-          ].map(tab => (
-            <button
-              key={tab.id}
-              className={`tab-button ${activeTab === tab.id ? 'active' : ''}`}
-              onClick={() => setActiveTab(tab.id)}
-            >
-              <span className="tab-icon">{tab.icon}</span>
-              {tab.label}
-            </button>
-          ))}
-        </div>
+        <div className="settings-main">
+          <div className="settings-sidebar">
+            {[
+              { id: 'audio', label: 'Audio', icon: '🎵' },
+              { id: 'video', label: 'Rendimiento', icon: '🎮' },
+              { id: 'fullscreen', label: 'Monitores', icon: '🖥️' },
+              { id: 'visual', label: 'Visuales', icon: '🎨' },
+              { id: 'system', label: 'Sistema', icon: '🔧' }
+            ].map(tab => (
+              <button
+                key={tab.id}
+                className={`tab-button ${activeTab === tab.id ? 'active' : ''}`}
+                onClick={() => setActiveTab(tab.id)}
+              >
+                <span className="tab-icon">{tab.icon}</span>
+                {tab.label}
+              </button>
+            ))}
+          </div>
 
-        {/* Content */}
-        <div className="settings-content">
+          {/* Content */}
+          <div className="settings-content">
           {/* Audio Tab */}
           {activeTab === 'audio' && (
             <div className="settings-section">
@@ -889,9 +889,10 @@ export const GlobalSettingsModal: React.FC<GlobalSettingsModalProps> = ({
             </div>
           )}
         </div>
+      </div>
 
-        {/* Footer */}
-        <div className="settings-footer">
+      {/* Footer */}
+      <div className="settings-footer">
           <div className="settings-info">
             <span>💡 Los cambios se aplican automáticamente</span>
           </div>


### PR DESCRIPTION
## Summary
- Reorganize GlobalSettings modal into two-column layout with sidebar navigation
- Shrink modal dimensions and fonts for a lighter, compact feel

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba3f84408333ab81538db8948acf