### PR TITLE
Refactor preset gallery and enforce Gen Lab canvas size

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,7 +34,7 @@ body {
 }
 
 .layer-grid-container {
-  overflow: hidden;
+  overflow: visible;
   background: #0A0A0A;
   margin: 0;
   padding: 0;
@@ -43,7 +43,7 @@ body {
   top: 40px;
   left: 0;
   width: 100%;
-  height: 300px;
+  height: auto;
   z-index: 5;
 }
 

--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -310,6 +310,33 @@
   border-radius: 8px;
 }
 
+/* Overrides for main preset list */
+.preset-gallery-main-grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-auto-rows: 112px;
+  gap: 15px;
+  overflow-y: auto;
+  height: 100%;
+  max-height: none;
+  padding: 10px;
+  background: #0F0F0F;
+  border-radius: 8px;
+}
+
+.preset-gallery-main-grid .preset-gallery-item {
+  width: 80%;
+  height: 80px;
+  margin: 0 auto;
+}
+
+.preset-gallery-main-grid .layer-button {
+  width: 19px;
+  height: 19px;
+  font-size: 10px;
+}
+
 .custom-text-grid {
   max-height: 200px;
 }
@@ -498,25 +525,49 @@
 
 /* Scrollbars */
 .preset-gallery-grid::-webkit-scrollbar,
-.preset-gallery-controls::-webkit-scrollbar {
+.controls-panel::-webkit-scrollbar {
   width: 8px;
 }
 
 .preset-gallery-grid::-webkit-scrollbar-track,
-.preset-gallery-controls::-webkit-scrollbar-track {
+.controls-panel::-webkit-scrollbar-track {
   background: #111;
   border-radius: 4px;
 }
 
 .preset-gallery-grid::-webkit-scrollbar-thumb,
-.preset-gallery-controls::-webkit-scrollbar-thumb {
+.controls-panel::-webkit-scrollbar-thumb {
   background: #333;
   border-radius: 4px;
 }
 
 .preset-gallery-grid::-webkit-scrollbar-thumb:hover,
-.preset-gallery-controls::-webkit-scrollbar-thumb:hover {
+.controls-panel::-webkit-scrollbar-thumb:hover {
   background: #555;
+}
+
+/* Layout elements */
+.controls-panel,
+.preset-gallery-placeholder {
+  width: 300px;
+  flex-shrink: 0;
+  border-left: 1px solid #444;
+  background: #1a1a1a;
+}
+
+.controls-panel {
+  padding: 20px;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.preset-gallery-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 40px;
+  overflow-y: auto;
 }
 
 /* Responsive */
@@ -552,234 +603,4 @@
     grid-auto-rows: 100px;
     gap: 10px;
   }
-}gallery-item:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
 }
-
-/* Controls Panel */
-.preset-gallery-controls {
-  width: 40%;
-  min-width: 400px;
-  border-left: 1px solid #444;
-  overflow-y: auto;
-  background: #1a1a1a;
-}
-
-.controls-panel {
-  padding: 20px;
-  height: 100%;
-}
-
-.controls-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 20px;
-  padding-bottom: 15px;
-  border-bottom: 1px solid #333;
-}
-
-.controls-header h3 {
-  margin: 0;
-  font-size: 20px;
-  color: #fff;
-}
-
-.preset-category-badge {
-  background: #444;
-  color: #ccc;
-  padding: 4px 12px;
-  border-radius: 12px;
-  font-size: 12px;
-  text-transform: uppercase;
-  font-weight: 600;
-}
-
-/* Custom Text Configuration */
-.custom-text-config {
-  background: rgba(100, 181, 246, 0.1);
-  border: 1px solid rgba(100, 181, 246, 0.3);
-  border-radius: 8px;
-  padding: 15px;
-  margin-bottom: 20px;
-}
-
-.config-section {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 10px;
-}
-
-.config-section label {
-  font-size: 14px;
-  color: #ccc;
-  font-weight: 500;
-}
-
-.count-controls {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.count-controls button {
-  background: #333;
-  border: 1px solid #555;
-  color: #fff;
-  width: 30px;
-  height: 30px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 16px;
-  font-weight: bold;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.count-controls button:hover:not(:disabled) {
-  background: #444;
-  border-color: #666;
-}
-
-.count-controls button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.count-display {
-  font-size: 16px;
-  font-weight: 600;
-  color: #64B5F6;
-  min-width: 30px;
-  text-align: center;
-}
-
-.config-description {
-  font-size: 12px;
-  color: #aaa;
-  line-height: 1.4;
-}
-
-/* Default Controls */
-.default-controls {
-  margin-top: 20px;
-}
-
-.default-controls h4 {
-  margin: 0 0 15px 0;
-  font-size: 16px;
-  color: #fff;
-  border-bottom: 1px solid #333;
-  padding-bottom: 8px;
-}
-
-/* Placeholder */
-.preset-gallery-placeholder {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  padding: 40px;
-}
-
-.placeholder-content {
-  text-align: center;
-  max-width: 300px;
-}
-
-.placeholder-icon {
-  font-size: 48px;
-  margin-bottom: 20px;
-}
-
-.placeholder-content h3 {
-  margin: 0 0 10px 0;
-  font-size: 24px;
-  color: #fff;
-}
-
-.placeholder-content p {
-  margin: 0 0 20px 0;
-  color: #ccc;
-  line-height: 1.5;
-}
-
-.placeholder-instructions {
-  text-align: left;
-  background: rgba(255, 255, 255, 0.05);
-  padding: 15px;
-  border-radius: 8px;
-  border-left: 3px solid #64B5F6;
-}
-
-.placeholder-instructions div {
-  margin-bottom: 8px;
-  font-size: 14px;
-  color: #ccc;
-}
-
-.placeholder-instructions div:last-child {
-  margin-bottom: 0;
-}
-
-.placeholder-instructions strong {
-  color: #64B5F6;
-}
-
-/* Scrollbars */
-.preset-gallery-grid::-webkit-scrollbar,
-.preset-gallery-controls::-webkit-scrollbar {
-  width: 8px;
-}
-
-.preset-gallery-grid::-webkit-scrollbar-track,
-.preset-gallery-controls::-webkit-scrollbar-track {
-  background: #111;
-  border-radius: 4px;
-}
-
-.preset-gallery-grid::-webkit-scrollbar-thumb,
-.preset-gallery-controls::-webkit-scrollbar-thumb {
-  background: #333;
-  border-radius: 4px;
-}
-
-.preset-gallery-grid::-webkit-scrollbar-thumb:hover,
-.preset-gallery-controls::-webkit-scrollbar-thumb:hover {
-  background: #555;
-}
-
-/* Responsive */
-@media (max-width: 1200px) {
-  .preset-gallery-modal {
-    width: 95%;
-    height: 95%;
-  }
-  
-  .preset-gallery-controls {
-    width: 50%;
-    min-width: 350px;
-  }
-}
-
-@media (max-width: 768px) {
-  .preset-gallery-content {
-    flex-direction: column;
-  }
-
-  .preset-gallery-grid {
-    height: 60%;
-  }
-
-  .preset-gallery-controls {
-    width: 100%;
-    height: 40%;
-    border-left: none;
-    border-top: 1px solid #444;
-  }
-}
-

--- a/src/components/PresetGalleryModal.tsx
+++ b/src/components/PresetGalleryModal.tsx
@@ -208,79 +208,74 @@ export const PresetGalleryModal: React.FC<PresetGalleryModalProps> = ({
         <div className="preset-gallery-content">
           {activeTab === 'main' ? (
             <>
-              <div className="preset-gallery-section">
-                <div className="preset-gallery-grid">
-                  {presets.map(preset => (
-                    <div key={preset.id} className="preset-gallery-item-wrapper">
-                      <div
-                        className="preset-gallery-item preset-cell"
-                        onClick={() => setSelected(preset)}
-                      >
-                        {preset.config.note !== undefined && (
-                          <div className="preset-note-badge">{preset.config.note}</div>
-                        )}
-                        <div className="preset-thumbnail">{getPresetThumbnail(preset)}</div>
-                        <div className="preset-info">
-                          <div className="preset-name">{preset.config.name}</div>
-                          <div className="preset-details">
-                            <span className="preset-category">{preset.config.category}</span>
-                          </div>
+              <div className="preset-gallery-grid preset-gallery-main-grid">
+                {presets.map(preset => (
+                  <div key={preset.id} className="preset-gallery-item-wrapper">
+                    <div
+                      className="preset-gallery-item preset-cell"
+                      onClick={() => setSelected(preset)}
+                    >
+                      {preset.config.note !== undefined && (
+                        <div className="preset-note-badge">{preset.config.note}</div>
+                      )}
+                      <div className="preset-thumbnail">{getPresetThumbnail(preset)}</div>
+                      <div className="preset-info">
+                        <div className="preset-name">{preset.config.name}</div>
+                        <div className="preset-details">
+                          <span className="preset-category">{preset.config.category}</span>
                         </div>
                       </div>
-
-                      {/* Botones de capas */}
-                      <div className="layer-button-group">
-                        {['A', 'B', 'C'].map(layer => (
-                          <button
-                            key={layer}
-                            className={`layer-button ${layerAssignments[layer].has(preset.id) ? 'active' : ''}`}
-                            onClick={e => {
-                              e.stopPropagation();
-                              toggleLayer(preset.id, layer);
-                            }}
-                          >
-                            {layer}
-                          </button>
-                        ))}
-                      </div>
                     </div>
-                  ))}
+
+                    {/* Botones de capas */}
+                    <div className="layer-button-group">
+                      {['A', 'B', 'C'].map(layer => (
+                        <button
+                          key={layer}
+                          className={`layer-button ${layerAssignments[layer].has(preset.id) ? 'active' : ''}`}
+                          onClick={e => {
+                            e.stopPropagation();
+                            toggleLayer(preset.id, layer);
+                          }}
+                        >
+                          {layer}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {selected ? (
+                <div className="controls-panel">
+                  <div className="controls-header">
+                    <h3>{selected.config.name}</h3>
+                    <span className="preset-category-badge">{selected.config.category}</span>
+                  </div>
+
+                  {/* Controles por defecto del preset */}
+                  <div className="default-controls">
+                    <h4>Valores por defecto:</h4>
+                    <PresetControls
+                      preset={selected}
+                      config={selected.config.defaultConfig || {}}
+                      onChange={handleDefaultControlChange}
+                    />
+                  </div>
                 </div>
-              </div>
-
-              {/* Panel de controles */}
-              <div className="preset-gallery-controls">
-                {selected ? (
-                  <div className="controls-panel">
-                    <div className="controls-header">
-                      <h3>{selected.config.name}</h3>
-                      <span className="preset-category-badge">{selected.config.category}</span>
-                    </div>
-
-                    {/* Controles por defecto del preset */}
-                    <div className="default-controls">
-                      <h4>Valores por defecto:</h4>
-                      <PresetControls
-                        preset={selected}
-                        config={selected.config.defaultConfig || {}}
-                        onChange={handleDefaultControlChange}
-                      />
+              ) : (
+                <div className="preset-gallery-placeholder">
+                  <div className="placeholder-content">
+                    <div className="placeholder-icon">🎯</div>
+                    <h3>Selecciona un preset</h3>
+                    <p>Haz click en un preset para ver y editar sus valores por defecto</p>
+                    <div className="placeholder-instructions">
+                      <div>• <strong>Click:</strong> Ver controles y configuración</div>
+                      <div>• <strong>A/B/C:</strong> Añadir o quitar de una layer</div>
                     </div>
                   </div>
-                ) : (
-                  <div className="preset-gallery-placeholder">
-                    <div className="placeholder-content">
-                      <div className="placeholder-icon">🎯</div>
-                      <h3>Selecciona un preset</h3>
-                      <p>Haz click en un preset para ver y editar sus valores por defecto</p>
-                      <div className="placeholder-instructions">
-                        <div>• <strong>Click:</strong> Ver controles y configuración</div>
-                        <div>• <strong>A/B/C:</strong> Añadir o quitar de una layer</div>
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </div>
+                </div>
+              )}
             </>
           ) : (
             <div className="preset-gallery-section templates-section">

--- a/src/presets/gen-lab/config.json
+++ b/src/presets/gen-lab/config.json
@@ -7,6 +7,8 @@
   "tags": ["cloud", "vapor", "skybox", "noise", "audio-reactive"],
   "thumbnail": "gen_lab_thumb.png",
   "defaultConfig": {
+    "width": 1920,
+    "height": 1080,
     "opacity": 1.0,
     "variant": "cloud",
     "noiseScale": 1.5,


### PR DESCRIPTION
## Summary
- Ensure Gen Lab presets default to 1920x1080 canvas size
- Allow layer grid container to expand to fit all layers
- Simplify preset gallery by embedding controls next to a scrollable preset list and shrinking preset tiles

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build` *(fails: Unable to find web assets "../dist" )*

------
https://chatgpt.com/codex/tasks/task_e_68a8c366274083339fad568504247b0f