### PR TITLE
Fix preset gallery layout and hide sidebar in modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1118,41 +1118,43 @@ const App: React.FC = () => {
             }}
           />
         </div>
-        <div className={`controls-panel ${isControlsOpen ? '' : 'collapsed'}`}>
-          <button
-            className="toggle-sidebar"
-            onClick={() =>
-              setIsControlsOpen(prev => {
-                const next = !prev;
-                localStorage.setItem('sidebarCollapsed', (!next).toString());
-                return next;
-              })
-            }
-          >
-            {isControlsOpen ? '✕' : '⚙️'}
-          </button>
-          {isControlsOpen && selectedPreset && (
-            <PresetControls
-              preset={selectedPreset}
-              config={layerPresetConfigs[selectedLayer!]?.[selectedPreset.id]}
-              onChange={(path, value) => {
-                if (engineRef.current && selectedLayer && selectedPreset) {
-                  engineRef.current.updateLayerPresetConfig(selectedLayer, path, value);
-                  setLayerPresetConfigs(prev => {
-                    const layerMap = { ...(prev[selectedLayer] || {}) };
-                    const cfg = { ...(layerMap[selectedPreset.id] || {}) };
-                    setNestedValue(cfg, path, value);
-                    layerMap[selectedPreset.id] = cfg;
-                    return { ...prev, [selectedLayer]: layerMap };
-                  });
-                }
-              }}
-            />
-          )}
-          {isControlsOpen && !selectedPreset && (
-            <div className="no-preset-selected">Selecciona un preset</div>
-          )}
-        </div>
+        {!isPresetGalleryOpen && (
+          <div className={`controls-panel ${isControlsOpen ? '' : 'collapsed'}`}>
+            <button
+              className="toggle-sidebar"
+              onClick={() =>
+                setIsControlsOpen(prev => {
+                  const next = !prev;
+                  localStorage.setItem('sidebarCollapsed', (!next).toString());
+                  return next;
+                })
+              }
+            >
+              {isControlsOpen ? '✕' : '⚙️'}
+            </button>
+            {isControlsOpen && selectedPreset && (
+              <PresetControls
+                preset={selectedPreset}
+                config={layerPresetConfigs[selectedLayer!]?.[selectedPreset.id]}
+                onChange={(path, value) => {
+                  if (engineRef.current && selectedLayer && selectedPreset) {
+                    engineRef.current.updateLayerPresetConfig(selectedLayer, path, value);
+                    setLayerPresetConfigs(prev => {
+                      const layerMap = { ...(prev[selectedLayer] || {}) };
+                      const cfg = { ...(layerMap[selectedPreset.id] || {}) };
+                      setNestedValue(cfg, path, value);
+                      layerMap[selectedPreset.id] = cfg;
+                      return { ...prev, [selectedLayer]: layerMap };
+                    });
+                  }
+                }}
+              />
+            )}
+            {isControlsOpen && !selectedPreset && (
+              <div className="no-preset-selected">Selecciona un preset</div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Barra de estado */}

--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -312,21 +312,20 @@
 
 /* Overrides for main preset list */
 .preset-gallery-main-grid {
-  flex: 1;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-auto-rows: 112px;
+  width: 100px;
+  flex: none;
+  display: flex;
+  flex-direction: column;
   gap: 15px;
   overflow-y: auto;
   height: 100%;
-  max-height: none;
   padding: 10px;
   background: #0F0F0F;
-  border-radius: 8px;
+  border-radius: 8px 0 0 8px;
 }
 
 .preset-gallery-main-grid .preset-gallery-item {
-  width: 80%;
+  width: 80px;
   height: 80px;
   margin: 0 auto;
 }
@@ -427,10 +426,6 @@
   background: #1a1a1a;
 }
 
-.controls-panel {
-  padding: 20px;
-  height: 100%;
-}
 
 .controls-header {
   display: flex;
@@ -525,37 +520,36 @@
 
 /* Scrollbars */
 .preset-gallery-grid::-webkit-scrollbar,
-.controls-panel::-webkit-scrollbar {
+.gallery-controls-panel::-webkit-scrollbar {
   width: 8px;
 }
 
 .preset-gallery-grid::-webkit-scrollbar-track,
-.controls-panel::-webkit-scrollbar-track {
+.gallery-controls-panel::-webkit-scrollbar-track {
   background: #111;
   border-radius: 4px;
 }
 
 .preset-gallery-grid::-webkit-scrollbar-thumb,
-.controls-panel::-webkit-scrollbar-thumb {
+.gallery-controls-panel::-webkit-scrollbar-thumb {
   background: #333;
   border-radius: 4px;
 }
 
 .preset-gallery-grid::-webkit-scrollbar-thumb:hover,
-.controls-panel::-webkit-scrollbar-thumb:hover {
+.gallery-controls-panel::-webkit-scrollbar-thumb:hover {
   background: #555;
 }
 
 /* Layout elements */
-.controls-panel,
+.gallery-controls-panel,
 .preset-gallery-placeholder {
-  width: 300px;
-  flex-shrink: 0;
+  flex: 1;
   border-left: 1px solid #444;
   background: #1a1a1a;
 }
 
-.controls-panel {
+.gallery-controls-panel {
   padding: 20px;
   height: 100%;
   overflow-y: auto;

--- a/src/components/PresetGalleryModal.tsx
+++ b/src/components/PresetGalleryModal.tsx
@@ -247,7 +247,7 @@ export const PresetGalleryModal: React.FC<PresetGalleryModalProps> = ({
               </div>
 
               {selected ? (
-                <div className="controls-panel">
+                <div className="gallery-controls-panel">
                   <div className="controls-header">
                     <h3>{selected.config.name}</h3>
                     <span className="preset-category-badge">{selected.config.category}</span>


### PR DESCRIPTION
## Summary
- Constrain preset gallery grid to 100px-wide vertical column and dedicate remaining space to preset controls
- Scope preset gallery controls styling to avoid leaking global sidebar styles
- Hide main sidebar when preset gallery modal is open

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Unable to find your web assets)


------
https://chatgpt.com/codex/tasks/task_e_68a8d0f9568883338d62b12f72cdfe6a