### PR TITLE
Standardize canvas resolution to 1080p

### DIFF
--- a/src/core/AudioVisualizerEngine.ts
+++ b/src/core/AudioVisualizerEngine.ts
@@ -188,8 +188,8 @@ export class AudioVisualizerEngine {
   }
 
   private updateSize(): void {
-    const width = window.innerWidth;
-    const height = window.innerHeight;
+    const width = 1920;
+    const height = 1080;
     const pixelRatio = Math.min(window.devicePixelRatio, 2);
     const visualScale = parseFloat(localStorage.getItem('visualScale') || '1');
     const scaledWidth = width * visualScale;
@@ -198,14 +198,12 @@ export class AudioVisualizerEngine {
     this.camera.aspect = width / height;
     this.camera.updateProjectionMatrix();
 
-    // Ajustar tamaño interno manteniendo el canvas llenando la pantalla
     this.renderer.setSize(scaledWidth, scaledHeight, false);
-    this.renderer.domElement.style.width = `${width}px`;
-    this.renderer.domElement.style.height = `${height}px`;
+    this.renderer.domElement.style.width = '100%';
+    this.renderer.domElement.style.height = '100%';
     this.renderer.setPixelRatio(pixelRatio);
 
-    // Actualizar render targets de layers con la escala aplicada
-    this.layers.forEach((layer, id) => {
+    this.layers.forEach((layer) => {
       if (layer.renderTarget) {
         layer.renderTarget.setSize(scaledWidth * pixelRatio, scaledHeight * pixelRatio);
       }

--- a/src/core/PresetLoader.ts
+++ b/src/core/PresetLoader.ts
@@ -357,6 +357,16 @@ export class PresetLoader {
       autoConfig.controls = [];
     }
 
+    if (!autoConfig.defaultConfig) {
+      autoConfig.defaultConfig = {} as any;
+    }
+    if (autoConfig.defaultConfig.width === undefined) {
+      autoConfig.defaultConfig.width = 1920;
+    }
+    if (autoConfig.defaultConfig.height === undefined) {
+      autoConfig.defaultConfig.height = 1080;
+    }
+
     return autoConfig;
   }
 


### PR DESCRIPTION
## Summary
- Force renderer to use a fixed 1920x1080 render size and scale canvas to full container
- Auto-fill preset default width/height to 1920x1080 so all visuals occupy the full canvas

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find your web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d775a9448333aad0c14b1ce8d90c