### PR TITLE
style: adjust preset gallery layout

### DIFF
--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -153,6 +153,7 @@
   display: flex;
   flex-direction: row;
   height: calc(100% - 80px);
+  justify-content: center;
 }
 
 /* Sections */
@@ -312,10 +313,11 @@
 
 /* Overrides for main preset list */
 .preset-gallery-main-grid {
-  width: 100px;
+  width: 115px;
   flex: none;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 15px;
   overflow-y: auto;
   height: 100%;
@@ -544,7 +546,9 @@
 /* Layout elements */
 .gallery-controls-panel,
 .preset-gallery-placeholder {
-  flex: 1;
+  flex: 0 0 60%;
+  max-width: 700px;
+  margin-left: 20px;
   border-left: 1px solid #444;
   background: #1a1a1a;
 }


### PR DESCRIPTION
## Summary
- Widen and center vertical preset grid in gallery modal
- Reduce controls panel width and center layout similar to Ableton preferences

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Unable to find your web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d97f210483339ebdc85917213612