### PR TITLE
Polish modal gallery and settings styling

### DIFF
--- a/src/components/GlobalSettingsModal.css
+++ b/src/components/GlobalSettingsModal.css
@@ -32,6 +32,8 @@
   overflow: hidden;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   animation: slideIn 0.3s ease;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 13px;
 }
 
 @keyframes fadeIn {
@@ -52,7 +54,7 @@
 
 /* Header */
 .settings-header {
-  padding: 15px 20px;
+  padding: 10px 16px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   display: flex;
   align-items: center;
@@ -63,8 +65,8 @@
 .settings-header h2 {
   color: var(--accent-color);
   margin: 0;
-  font-size: 20px;
-  font-weight: 600;
+  font-size: 18px;
+  font-weight: 500;
 }
 
 .close-button {
@@ -112,14 +114,14 @@
   background: transparent;
   border: none;
   color: #ccc;
-  padding: 10px 20px;
+  padding: 6px 12px;
   cursor: pointer;
   transition: all 0.2s ease;
-  border-left: 3px solid transparent;
+  border-left: 2px solid transparent;
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
+  gap: 6px;
+  font-size: 12px;
   font-weight: 500;
   width: 100%;
   text-align: left;
@@ -221,8 +223,8 @@
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 8px;
   color: #fff;
-  padding: 8px 10px;
-  font-size: 13px;
+  padding: 6px 8px;
+  font-size: 12px;
   transition: all 0.2s ease;
 }
 
@@ -285,7 +287,7 @@
 
 .setting-slider {
   padding: 0;
-  height: 8px;
+  height: 6px;
   -webkit-appearance: none;
   appearance: none;
   background: rgba(255, 255, 255, 0.2);
@@ -295,8 +297,8 @@
 .setting-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  width: 20px;
-  height: 20px;
+  width: 14px;
+  height: 14px;
   background: var(--accent-color);
   border-radius: 50%;
   cursor: pointer;
@@ -312,15 +314,15 @@
 .setting-checkbox {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
   color: #fff;
-  font-size: 13px;
+  font-size: 12px;
   cursor: pointer;
 }
 
 .setting-checkbox input[type="checkbox"] {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   accent-color: var(--accent-color);
   cursor: pointer;
 }

--- a/src/components/PresetControls.css
+++ b/src/components/PresetControls.css
@@ -1,10 +1,12 @@
 /* PresetControls.css */
 
 .preset-controls {
-  padding: 15px;
+  padding: 10px;
   background: #1a1a1a;
   border-radius: 8px;
   color: #fff;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 13px;
 }
 
 .preset-controls.read-only {
@@ -73,12 +75,12 @@
 
 /* Select Controls */
 .control-select {
-  padding: 10px 12px;
+  padding: 6px 10px;
   background: #333;
   border: 1px solid #555;
   border-radius: 6px;
   color: #fff;
-  font-size: 14px;
+  font-size: 12px;
   cursor: pointer;
   transition: all 0.2s ease;
 }
@@ -264,7 +266,7 @@
 }
 
 .control-label {
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 600;
   color: #fff;
   display: flex;
@@ -281,12 +283,12 @@
 .slider-container {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 
 .control-slider {
   flex: 1;
-  height: 6px;
+  height: 4px;
   background: #333;
   border-radius: 3px;
   outline: none;
@@ -295,8 +297,8 @@
 
 .control-slider::-webkit-slider-thumb {
   appearance: none;
-  width: 18px;
-  height: 18px;
+  width: 12px;
+  height: 12px;
   background: #64B5F6;
   border-radius: 50%;
   cursor: pointer;
@@ -315,13 +317,13 @@
 }
 
 .slider-number {
-  width: 60px;
-  padding: 6px;
+  width: 50px;
+  padding: 4px;
   background: #333;
   border: 1px solid #555;
   border-radius: 4px;
   color: #fff;
-  font-size: 12px;
+  font-size: 11px;
   text-align: right;
 }
 
@@ -333,12 +335,12 @@
 }
 
 .control-text {
-  padding: 10px 12px;
+  padding: 6px 10px;
   background: #333;
   border: 1px solid #555;
   border-radius: 6px;
   color: #fff;
-  font-size: 14px;
+  font-size: 12px;
   transition: all 0.2s ease;
 }
 
@@ -417,8 +419,8 @@
 }
 
   .checkbox-custom {
-    width: 18px;
-    height: 18px;
+    width: 14px;
+    height: 14px;
     border: 2px solid #555;
     border-radius: 4px;
     background: #333;

--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -31,6 +31,8 @@
   border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 13px;
 }
 
 .preset-gallery-modal.small {
@@ -43,15 +45,15 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 20px;
+  padding: 8px 16px;
   background: linear-gradient(135deg, #333, #2a2a2a);
   border-bottom: 1px solid #444;
 }
 
 .preset-gallery-header h2 {
   margin: 0;
-  font-size: 24px;
-  font-weight: 600;
+  font-size: 18px;
+  font-weight: 500;
 }
 
 /* Tabs */
@@ -65,80 +67,24 @@
   background: #2a2a2a;
   border: none;
   color: #fff;
-  padding: 8px 12px;
+  padding: 6px 10px;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 12px;
 }
 
 .tab-button.active {
   background: #333;
   font-weight: 600;
+  border-bottom: 2px solid #64B5F6;
 }
 
 .close-button {
   background: none;
   border: none;
   color: #fff;
-  font-size: 24px;
+  font-size: 18px;
   cursor: pointer;
-  padding: 5px 10px;
-  border-radius: 4px;
-  transition: background-color 0.2s ease;
-}
-
-.close-button:hover {
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.preset-gallery-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0,0,0,0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  transition: opacity 0.2s ease;
-}
-
-.preset-gallery-modal {
-  background: #222;
-  color: #fff;
-  width: 80%;
-  height: 80%;
-  display: flex;
-  flex-direction: column;
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
-}
-
-/* Header */
-.preset-gallery-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px 20px;
-  background: linear-gradient(135deg, #333, #2a2a2a);
-  border-bottom: 1px solid #444;
-}
-
-.preset-gallery-header h2 {
-  margin: 0;
-  font-size: 24px;
-  font-weight: 600;
-}
-
-.close-button {
-  background: none;
-  border: none;
-  color: #fff;
-  font-size: 24px;
-  cursor: pointer;
-  padding: 5px 10px;
+  padding: 4px 8px;
   border-radius: 4px;
   transition: background-color 0.2s ease;
 }
@@ -159,8 +105,8 @@
 /* Sections */
 .preset-gallery-section {
   flex: none;
-  width: 140px;
-  padding: 20px 10px;
+  width: 120px;
+  padding: 15px 8px;
   border-right: 1px solid #333;
   border-bottom: none;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- Apply compact Windows-style fonts and spacing to preset gallery modal
- Use tighter typography and control dimensions in global settings modal
- Shrink preset control sliders, inputs and checkboxes for a more refined look

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Unable to find web assets)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ef568af883339fa31373552c160d