### PR TITLE
Add LaunchPad presets gallery and custom text marquee

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,8 @@ import {
   LaunchpadPreset,
   isLaunchpadDevice,
   gridIndexToNote,
-  canvasToLaunchpadFrame
+  canvasToLaunchpadFrame,
+  LAUNCHPAD_PRESETS
 } from './utils/launchpad';
 import './App.css';
 import './components/LayerGrid.css';
@@ -105,6 +106,7 @@ const App: React.FC = () => {
   const [launchpadChannel, setLaunchpadChannel] = useState(() => parseInt(localStorage.getItem('launchpadChannel') || '1'));
   const [launchpadNote, setLaunchpadNote] = useState(() => parseInt(localStorage.getItem('launchpadNote') || '60'));
   const [launchpadSmoothness, setLaunchpadSmoothness] = useState(() => parseFloat(localStorage.getItem('launchpadSmoothness') || '0'));
+  const [launchpadText, setLaunchpadText] = useState(() => localStorage.getItem('launchpadText') || 'HELLO');
   const [layerEffects, setLayerEffects] = useState<Record<string, { effect: string; alwaysOn: boolean; active: boolean }>>(() => {
     try {
       const stored = localStorage.getItem('layerEffects');
@@ -281,6 +283,10 @@ const App: React.FC = () => {
   useEffect(() => {
     localStorage.setItem('launchpadSmoothness', launchpadSmoothness.toString());
   }, [launchpadSmoothness]);
+
+  useEffect(() => {
+    localStorage.setItem('launchpadText', launchpadText);
+  }, [launchpadText]);
 
   // Enumerar monitores disponibles usando Electron
   useEffect(() => {
@@ -672,7 +678,7 @@ const App: React.FC = () => {
         ? canvasRef.current
           ? canvasToLaunchpadFrame(canvasRef.current)
           : new Array(64).fill(0)
-        : buildLaunchpadFrame(launchpadPreset, audioData);
+        : buildLaunchpadFrame(launchpadPreset, audioData, { text: launchpadText });
 
     // 🔥 DEBUG CRUCIAL: Verificar que frame tiene 64 elementos
     if (rawFrame.length !== 64) {
@@ -702,7 +708,7 @@ const App: React.FC = () => {
       }
     });
 
-  }, [audioData, launchpadRunning, launchpadPreset, launchpadOutput, launchpadSmoothness]);
+  }, [audioData, launchpadRunning, launchpadPreset, launchpadOutput, launchpadSmoothness, launchpadText]);
 
   useEffect(() => {
     if (launchpadRunning && launchpadOutput) {
@@ -1530,6 +1536,13 @@ const App: React.FC = () => {
         onGenLabPresetsChange={handleGenLabPresetsChange}
         onAddPresetToLayer={handleAddPresetToLayer}
         onRemovePresetFromLayer={handleRemovePresetFromLayer}
+        launchpadPresets={LAUNCHPAD_PRESETS}
+        launchpadPreset={launchpadPreset}
+        onLaunchpadPresetChange={setLaunchpadPreset}
+        launchpadRunning={launchpadRunning}
+        onToggleLaunchpad={() => setLaunchpadRunning(r => !r)}
+        launchpadText={launchpadText}
+        onLaunchpadTextChange={setLaunchpadText}
       />
     </div>
   );

--- a/src/components/PresetGalleryModal.css
+++ b/src/components/PresetGalleryModal.css
@@ -311,6 +311,34 @@
   border-left: 1px solid rgba(255,255,255,0.1);
 }
 
+.launchpad-layout {
+  flex: 1;
+  display: flex;
+  height: 100%;
+}
+
+.launchpad-selector {
+  flex: 0 0 180px;
+  background: rgba(0,0,0,0.2);
+  border-right: 1px solid rgba(255,255,255,0.1);
+  padding: 15px 10px;
+  overflow-y: auto;
+}
+
+.launchpad-selector-grid {
+  grid-template-columns: 1fr;
+  grid-auto-rows: 120px;
+  gap: 15px;
+}
+
+.launchpad-controls-panel {
+  flex: 1;
+  padding: 20px;
+  overflow-y: auto;
+  background: #1a1a1a;
+  border-left: 1px solid rgba(255,255,255,0.1);
+}
+
 .preset-gallery-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, 120px);


### PR DESCRIPTION
## Summary
- add LaunchPad Presets tab to preset gallery with start/stop and custom text input
- introduce Launchpad custom-text preset that scrolls text like an LED marquee
- persist launchpad text setting and wire gallery to launchpad controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: many TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f20db3188333a6468a74673b32ef